### PR TITLE
CASMTRIAGE-3475 fix master node exclusion in UAI make_node_groups

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.0.38] - 2022-07-25
+### Changed
+ - Update make_node_groups to handle K8s output change
+
 ## [0.0.37] - 2022-07-20
 ### Changed
  - Update run_hms_ct_tests.sh for improved log output formatting.


### PR DESCRIPTION
## Summary and Scope

The newer version of K8s in CSM changed the output of some `kubectl get nodes` output. This broke some parsing that was attempting to get a list of all worker nodes in the script make_node_groups. As a result, master nodes were included in the list.

Use a more deterministic method of filtering the output to exclude the master nodes fixes the issue. 


## Issues and Related PRs

* Resolves [CASMTRIAGE-3475](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3475)

## Testing

mug

### Tested on:

  * `mug`
  * Local development environment
  * Virtual Shasta

### Test description:

The modified script created an HSM group that did not include the master nodes. Before the change master nodes were included in the HSM group `uai`.

## Risks and Mitigations

Low risk, small change that excludes master nodes


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

