### PR TITLE
CASMHMS-5603/CASMHMS-5614 Updates for HMS Helm CT tests 2, pt. 2 and HSM v1 API deprecation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.0.35] - 2022-07-07
+### Changed
+ - Updates to run_hms_ct_tests.sh to run Helm versions of CT tests.
+ - Update make_node_groups to handle K8s output change.
+
 ## [0.0.33] - 2022-05-09
 ### Changed
  - Change dns_records.py to use the NMN API gateway for the calls to SLS.

--- a/changelog.md
+++ b/changelog.md
@@ -1,9 +1,10 @@
 # Changelog
 
-## [0.0.35] - 2022-07-07
+## [0.0.35] - 2022-07-12
 ### Changed
  - Updates to run_hms_ct_tests.sh to run Helm versions of CT tests.
  - Update make_node_groups to handle K8s output change.
+ - Update verify_hsm_discovery.py to use HSM v2 instead of v1 which is deprecated.
 
 ## [0.0.33] - 2022-05-09
 ### Changed

--- a/scripts/hms_verification/verify_hsm_discovery.py
+++ b/scripts/hms_verification/verify_hsm_discovery.py
@@ -117,7 +117,7 @@ def doRest(uri, authToken):
 # Get HSM component data
 
 def getHSMComponents(authToken):
-	url = "https://api-gw-service-nmn.local/apis/smd/hsm/v1/State/Components"
+	url = "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components"
 	compsJSON, rstat = doRest(url, authToken)
 	return compsJSON, rstat
 
@@ -126,7 +126,7 @@ def getHSMComponents(authToken):
 # Get HSM RFEP data
 
 def getHSMRFEP(authToken):
-	url = "https://api-gw-service-nmn.local/apis/smd/hsm/v1/Inventory/RedfishEndpoints"
+	url = "https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints"
 	rfepJSON, rstat = doRest(url, authToken)
 	return rfepJSON, rstat
 

--- a/scripts/node_management/make_node_groups
+++ b/scripts/node_management/make_node_groups
@@ -31,8 +31,8 @@ list_hsm_nodes() {
 
 list_uai_nodes() {
     kubectl get nodes \
-            --selector "uas notin (false, False, FALSE)" \
-        | grep -v -e ' master ' -e '^NAME ' \
+            --selector "uas notin (false, False, FALSE),! node-role.kubernetes.io/master" \
+        | grep -v -e '^NAME ' \
         | awk '{ print $1 }'
 }
 


### PR DESCRIPTION
### Summary and Scope

This PR includes changes for three scripts used for HMS CT testing during the CSM health checks:

- run_hms_ct_tests.sh

This test wrapper script has been refactored for running the new Helm versions of the HMS CT tests which are no longer packaged as RPMs on the NCNs.

- hsm_discovery_status_test.sh

This test script previously lived in the hms-smd repository and ran as a CT smoke test but it's being moved here since it was a one-off test of a different type than the others and is better suited to run here along with the other discovery validation tests.

- verify_hsm_discovery.py

The test script is updated to use HSM v2 APIs instead of v1 which are deprecated and being removed.

Lastly, it adds the changes from the 0.0.34 tag into master which was made on the release/1.2 branch but will also be needed in csm-1.3 and beyond.

### Issues and Related PRs

* Resolves CASMHMS-5603.
* Resolves CASMHMS-5614.

### Testing

This change was tested by deploying the updated versions of the HMS services and charts onto Mug, executing the CT tests, and verifying that they passed.

Was a fresh Install tested? N
Was an Upgrade tested? Y
Was a Downgrade tested? N

### Risks and Mitigations

Low risk, test update.