### PR TITLE
CASMHMS-5617: Remove WAR for bad SLS chassis data generation.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.0.36] - 2022-07-14
+
+### Changed
+- Remove WAR for bad SLS chassis data generation from verify_hsm_discovery.py.
+
 ## [0.0.35] - 2022-07-12
 ### Changed
  - Updates to run_hms_ct_tests.sh to run Helm versions of CT tests.

--- a/scripts/hms_verification/verify_hsm_discovery.py
+++ b/scripts/hms_verification/verify_hsm_discovery.py
@@ -502,7 +502,7 @@ def genMountainDetails(slsData, compData, rfepData):
 
 			# Check RF Endpoints presence
 			flds = rfepJSON['RedfishEndpoints']
-			filtered = list(filter(lambda f: (f['ID'] == bname+"b0"), flds))
+			filtered = list(filter(lambda f: (f['ID'] == bname), flds))
 			if not filtered:
 				if len(noc) > 0:
 					noc += "; "


### PR DESCRIPTION
Also migrate to HSM v2 APIs

## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_
The verify_hsm_discovery.py script had a WAR in place for bad SLS chassis data generation, and the bug causing this was fixed in https://github.com/Cray-HPE/cray-site-init/pull/203 .


_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMHMS-5617](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5617)

## Testing

_List the environments in which these changes were tested._

### Tested on:
  * `Mug`
  * Local development environment

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N/A
- Were continuous integration tests run? If not, why? N/A
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

__Mug testing__
Ran the modified script on Mug, and 2 errors reports are expected (ncn-m001 BMC and the phantom Intel CMC).
```
HSM Cabinet Summary
===================
x3000 (River)
  Discovered Nodes:          19 (14 Mgmt, 1 Application, 4 Compute)
  Discovered Node BMCs:      18
  Discovered Router BMCs:     1
  Discovered Chassis BMCs:    0
  Discovered Cab PDU Ctlrs:   0
x3001 (River)
  Discovered Nodes:           5 (5 Mgmt, 0 Application, 0 Compute)
  Discovered Node BMCs:       5
  Discovered Router BMCs:     0
  Discovered Chassis BMCs:    0
  Discovered Cab PDU Ctlrs:   0

River Cabinet Checks
====================
x3000
  Nodes: PASS
  NodeBMCs: WARNING
    - x3000c0s1b0 - Not found in HSM Components; No mgmt port connection; BMC of mgmt node ncn-m001.
  RouterBMCs: PASS
  ChassisBMCs/CMCs: FAIL
    - x3000c0s19b999 - Not found in HSM Components; Not found in HSM Redfish Endpoints; No mgmt port connection.
  CabinetPDUControllers: PASS
x3001
  Nodes: PASS
  NodeBMCs: PASS
  RouterBMCs: PASS
  ChassisBMCs/CMCs: PASS
  CabinetPDUControllers: PASS

Mountain/Hill Cabinet Checks
============================
None Found.
```

__Local testing__
Simulated environment using hms-simulation-environment with a Hill system with CSI data generated from this PR https://github.com/Cray-HPE/cray-site-init/pull/203 

```
HSM Cabinet Summary
===================
x3000 (River)
  Discovered Nodes:          13 (10 Mgmt, 2 Application, 1 Compute)
  Discovered Node BMCs:      13
  Discovered Router BMCs:     2
  Discovered Chassis BMCs:    0
  Discovered Cab PDU Ctlrs:   0
x9000 (Hill)
  Discovered Nodes:          64
  Discovered Node BMCs:      32
  Discovered Router BMCs:    16
  Discovered Chassis BMCs:    2

River Cabinet Checks
====================
x3000
  Nodes: PASS
  NodeBMCs: WARNING
    - x3000c0s1b0 - No mgmt port connection; BMC of mgmt node ncn-m001.
  RouterBMCs: PASS
  ChassisBMCs/CMCs: PASS
  CabinetPDUControllers: WARNING
    - x3000m1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x3000m0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.

Mountain/Hill Cabinet Checks
============================
x9000 (Hill)
  ChassisBMCs: PASS
  Nodes: PASS
  NodeBMCs: PASS
  RouterBMCs: PASS
```

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_
Low risk.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

