### PR TITLE
CASMHMS-5743 Fix token leaks in HMS test script

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.0.39] - 2022-09-09
+### Changed
+ - Update hsm_discovery_status_test.sh to fix token leaks.
+
 ## [0.0.38] - 2022-07-25
 ### Changed
  - Add workaround to dns_records.py to allow for hostnames with _

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ## [0.0.39] - 2022-09-09
 ### Changed
  - Update hsm_discovery_status_test.sh to fix token leaks.
+ - Clean up run_hms_ct_tests.sh for shellcheck.
 
 ## [0.0.38] - 2022-07-25
 ### Changed

--- a/scripts/hms_verification/hsm_discovery_status_test.sh
+++ b/scripts/hms_verification/hsm_discovery_status_test.sh
@@ -73,7 +73,7 @@ function get_client_secret()
 {
     # get client secret from Kubernetes
     KUBECTL_GET_SECRET_CMD="kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}'"
-    >&2 echo $(timestamp_print "Getting client secret...")
+    >&2 echo "$(timestamp_print "Getting client secret...")"
     KUBECTL_GET_SECRET_OUT=$(eval ${KUBECTL_GET_SECRET_CMD})
     KUBECTL_GET_SECRET_RET=$?
     if [[ ${KUBECTL_GET_SECRET_RET} -ne 0 ]] ; then
@@ -117,7 +117,7 @@ function get_auth_token()
     fi
     KEYCLOAK_TOKEN_URI="https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token"
     KEYCLOAK_TOKEN_CMD="curl -k -i -s -S -d grant_type=client_credentials -d client_id=admin-client -d client_secret=${CLIENT_SECRET} ${KEYCLOAK_TOKEN_URI}"
-    >&2 echo $(timestamp_print "Retrieving authentication token...")
+    >&2 echo "$(timestamp_print "Retrieving authentication token...")"
     KEYCLOAK_TOKEN_OUT=$(eval ${KEYCLOAK_TOKEN_CMD})
     KEYCLOAK_TOKEN_RET=$?
     if [[ ${KEYCLOAK_TOKEN_RET} -ne 0 ]] ; then


### PR DESCRIPTION
### Summary and Scope

This change fixes Keycloak authentication token leaks in the hsm_discovery_status_test.sh script. Previously the test output and logs would contain previously used tokens, now these tokens are redacted.

Example output:

```
ncn-m001:~/schooler # ./hsm_discovery_status_test.sh
Running hsm_discovery_status_test...
(17:29:51) Getting client secret...
(17:29:51) Retrieving authentication token...
(17:29:51) Testing 'curl -s -k -H "Authorization: Bearer <REDACTED>" https://api-gw-service-nmn.local/apis/smd/hsm/v2/Inventory/RedfishEndpoints'...
(17:29:51) Processing response with: 'jq '.RedfishEndpoints[] | { ID: .ID, LastDiscoveryStatus: .DiscoveryInfo.LastDiscoveryStatus}' -c | sort -V | jq -c'...
(17:29:52) Verifying endpoint discovery statuses...
PASS: hsm_discovery_status_test passed!
```

### Issues and Related PRs

* Resolves CASMHMS-5743.

### Testing

This change was tested on Fanta by running the updated version of the script under various pass/fail conditions and verifying that the previously printed tokens were no longer present in the test output.

Was a fresh Install tested? Y
Was an Upgrade tested? N/A
Was a Downgrade tested? N/A

### Risks and Mitigations

Low risk, security improvement.