### PR TITLE
CASMHMS-5782 Don't require a user to delete when configuring Aruba switches

### DIFF
--- a/scripts/hms_verification/leaf_switch_snmp_creds.sh
+++ b/scripts/hms_verification/leaf_switch_snmp_creds.sh
@@ -152,7 +152,9 @@ send \"exit\n\"
 		return 1
 	fi
 
- 	outtext2=$(expect -c "
+	outtext2=""
+	if [[ ! -z "${SNMPDelUser}" ]]; then
+		outtext2=$(expect -c "
 spawn ssh admin@${swname}
 expect \"password: \"
 send \"${MGMTPW}\n\"
@@ -168,22 +170,25 @@ expect \"# \"
 send \"exit\n\"
 ")
 
-	if [ $? -ne 0 ]; then
-		echo "Communication with $swname failed."
-		echo " "
-		echo "Communication log:"
-		echo " "
-		echo $outtext2
-		echo " "
-		return 1
+		if [ $? -ne 0 ]; then
+			echo "Communication with $swname failed."
+			echo " "
+			echo "Communication log:"
+			echo " "
+			echo $outtext2
+			echo " "
+			return 1
+		fi
 	fi
 
 	echo "Aruba switch $swname SNMP cred reset succeeded."
 
 	if (( debugLevel > 1 )); then
 		echo $outtext
-		echo " "
-		echo $outtext2
+		if [[ ! -z "${SNMPDelUser}" ]]; then
+			echo " "
+			echo $outtext2
+		fi
 	fi
 
 	return 0
@@ -285,8 +290,7 @@ fi
 
 if [[ -z "${SNMPDELUSER}" ]]; then
 	echo " "
-	echo -n "==> Enter 'bad' default SNMP user ID to remove: "
-	read SNMPDelUser
+	echo "Skipping user deletion, SNMPDELUSER not supplied or is empty."
 else
 	SNMPDelUser=${SNMPDELUSER}
 fi
@@ -336,8 +340,10 @@ else
 fi
 
 if (( debugLevel > 0 )); then
-	echo "Removing SNMP user ID: ${SNMPDelUser}"
 	echo "Adding new SNMP user ID: ${SNMPNewUser}"
+	if [[ ! -z "${SNMPDelUser}" ]]; then
+		echo "Removing SNMP user ID: ${SNMPDelUser}"
+	fi
 	echo "SNMP auth password: ${SNMPAuthPW}"
 	echo "SNMP priv password: ${SNMPPrivPW}"
 fi


### PR DESCRIPTION
## Summary and Scope
The script that configures SNMP on Dell and Aruba switches expects a user to delete from the Aruba switches. Unfortunately the delete happens after the creation of the new user and if they are the same name, the new user is deleted leaving the switch as it was before the script is executed. Updated the script to not require the delete user name. This allows both a creation method and a way to delete bad user names.

Behavior will not change when the same command line from the documentation is used.

## Issues and Related PRs

* Resolves [CASMHMS-5782](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5782)
* Documentation changes required in [CASMHMS-5782](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5782)

## Testing
### Tested on:

  * `loki`

### Test description:

Copied a modified version of the script to loki and executed with an alternative username for the Aruba SNMPv3 configuration. Validated that I could create the new user without deleting it and then create a new users while deleting the old bad user.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N - N/A
- Was upgrade tested? If not, why? N - Installed via RPM
- Was downgrade tested? If not, why? N - Installed via RPM
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

No known risks.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

