### PR TITLE
CASMHMS-5784 Fix broken HSM CLI call in make_node_groups script Main

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.4.1] - 2022-10-27
+### Changed
+- Fixed broken HSM CLI call in make_node_groups script.
+
 ## [0.4.0] - 2022-10-26
 ### Changed
 - verify_hsm_discovery.py now references troubleshooting documentation upon failure.
@@ -7,7 +11,7 @@
 ## [0.0.40] - 2022-10-12
 ### Changed
 - Modify leaf_switch_snmp_creds.sh to not require a user to delete
-- 
+
 ## [0.0.39] - 2022-09-09
 ### Changed
  - Update hsm_discovery_status_test.sh to fix token leaks.

--- a/scripts/node_management/make_node_groups
+++ b/scripts/node_management/make_node_groups
@@ -1,5 +1,6 @@
 #! /bin/bash
-# Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+
+# Copyright 2020-2022 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -23,7 +24,7 @@ set -e
 
 list_hsm_nodes() {
     cray hsm state components list \
-         --type node \
+         --type Node \
          --role management \
          --subrole $1 \
          --format json | jq -r .Components[].ID


### PR DESCRIPTION
### Summary and Scope

This change fixes a broken HSM CLI call in the make_node_groups script.

### Issues and Related PRs

* Resolves [CASMHMS-5784](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5784).

### Testing

This change was tested by running the updated CLI call and verifying that the errors previously encountered no longer occurred.

Before fix:
```
ncn-m001:~ # cray hsm state components list --type node --role management --subrole master --format json | jq
Usage: cray hsm state components list [OPTIONS]
Try 'cray hsm state components list --help' for help.

Error: Invalid value for '--type': invalid choice: node. (choose from CDU, CabinetCDU, CabinetPDU, CabinetPDUOutlet, CabinetPDUPowerConnector, CabinetPDUController, Cabinet, Chassis, ChassisBMC, CMMRectifier, CMMFpga, CEC, ComputeModule, RouterModule, NodeBMC, NodeEnclosure, NodeEnclosurePowerSupply, HSNBoard, Node, Processor, Drive, StorageGroup, NodeNIC, Memory, NodeAccel, NodeAccelRiser, NodeFpga, HSNAsic, RouterFpga, RouterBMC, HSNLink, HSNConnector, INVALID)
```

After fix:
```
ncn-m001:~ # cray hsm state components list --type Node --role management --subrole master --format json | jq
{
  "Components": [
    {
      "ID": "x3000c0s3b0n0",
      "Type": "Node",
      "State": "Ready",
      "Flag": "OK",
      "Enabled": true,
      "Role": "Management",
      "SubRole": "Master",
      "NID": 100007,
      "NetType": "Sling",
      "Arch": "X86",
      "Class": "River",
      "Locked": true
    },
    <snip>
  ]
}
```

Was a fresh Install tested? Y
Was an Upgrade tested? N
Was a Downgrade tested? N

### Risks and Mitigations

Low risk.