### PR TITLE
MTL-1708 Build & Publish SP4 RPMs

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2022 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),
@@ -27,8 +27,8 @@
 
 def isStable = env.TAG_NAME != null ? true : false
 def sleImage = 'artifactory.algol60.net/csm-docker/stable/csm-docker-sle'
-def sleVersion = '15.3'
 pipeline {
+
     agent {
         label "metal-gcp-builder"
     }
@@ -46,41 +46,78 @@ pipeline {
     }
 
     stages {
-        stage('Prepare: RPMs') {
-            // Make RPM MetaData in our target environment (SLE).
-            agent {
-                docker {
-                    label 'docker'
-                    reuseNode true
-                    image "${sleImage}:${sleVersion}"
-                }
-            }
-            steps {
-                runLibraryScript("addRpmMetaData.sh", "${env.GIT_REPO_NAME}.spec")
-                sh "make rpm_prepare"
-                sh "git update-index --assume-unchanged ${env.NAME}.spec"
-            }
-        }
 
-        stage('Build: RPMs') {
-            agent {
-                docker {
-                    image "${sleImage}:${sleVersion}"
-                    reuseNode true
-                }
-            }
-            steps {
-                sh "make rpm"
-            }
-        }
+        stage('Build & Publish') {
 
-        stage('Publish: RPMs') {
-            steps {
-                script {
-                    publishCsmRpms(component: env.NAME, pattern: "dist/rpmbuild/RPMS/noarch/*.rpm", os: 'sle-15sp2', arch: "noarch", isStable: isStable)
-                    publishCsmRpms(component: env.NAME, pattern: "dist/rpmbuild/RPMS/noarch/*.rpm", os: 'sle-15sp3', arch: "noarch", isStable: isStable)
-                    publishCsmRpms(component: env.NAME, pattern: "dist/rpmbuild/SRPMS/*.rpm", os: 'sle-15sp2', arch: "src", isStable: isStable)
-                    publishCsmRpms(component: env.NAME, pattern: "dist/rpmbuild/SRPMS/*.rpm", os: 'sle-15sp3', arch: "src", isStable: isStable)
+            matrix {
+
+                agent {
+                    node {
+                        label "metal-gcp-builder"
+                        customWorkspace "${env.WORKSPACE}/${sleVersion}"
+                    }
+                }
+
+                axes {
+                    axis {
+                        name 'sleVersion'
+                        values 15.3, 15.4
+                    }
+                }
+
+                stages {
+
+                    stage('Prepare: RPMs') {
+                        agent {
+                            docker {
+                                label 'docker'
+                                reuseNode true
+                                image "${sleImage}:${sleVersion}"
+                            }
+                        }
+                        steps {
+                            runLibraryScript("addRpmMetaData.sh", "${env.NAME}.spec")
+                            sh "make prepare"
+                            sh "git update-index --assume-unchanged ${env.NAME}.spec"
+                        }
+                    }
+
+                    stage('Build: RPMs') {
+                        agent {
+                            docker {
+                                label 'docker'
+                                reuseNode true
+                                image "${sleImage}:${sleVersion}"
+                            }
+                        }
+                        steps {
+                            sh "make rpm"
+                        }
+                    }
+
+                    stage('Publish: RPMs') {
+                        steps {
+                            script {
+                                sles_version_parts = "${sleVersion}".tokenize('.')
+                                sles_major = "${sles_version_parts[0]}"
+                                sles_minor = "${sles_version_parts[1]}"
+                                publishCsmRpms(
+                                        arch: "noarch",
+                                        component: env.NAME,
+                                        isStable: isStable,
+                                        os: "sle-${sles_major}sp${sles_minor}",
+                                        pattern: "dist/rpmbuild/RPMS/noarch/*.rpm",
+                                )
+                                publishCsmRpms(
+                                        arch: "src",
+                                        component: env.NAME,
+                                        isStable: isStable,
+                                        os: "sle-${sles_major}sp${sles_minor}",
+                                        pattern: "dist/rpmbuild/SRPMS/*.rpm",
+                                )
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/Makefile
+++ b/Makefile
@@ -33,9 +33,9 @@ RPM_SOURCE_NAME ?= ${NAME}-${VERSION}
 RPM_BUILD_DIR ?= $(PWD)/dist/rpmbuild
 RPM_SOURCE_PATH := ${RPM_BUILD_DIR}/SOURCES/${RPM_SOURCE_NAME}.tar.bz2
 
-rpm: rpm_prepare rpm_package_source rpm_build_source rpm_build
+rpm: prepare rpm_package_source rpm_build_source rpm_build
 
-rpm_prepare:
+prepare:
 	rm -rf $(RPM_BUILD_DIR)
 	mkdir -p $(RPM_BUILD_DIR)/SPECS $(RPM_BUILD_DIR)/SOURCES
 	cp $(SPEC_FILE) $(RPM_BUILD_DIR)/SPECS/


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: MTL-1708

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
Continue to build and publish SP3 RPMs while publishing SP4 RPMs. Include the correct, respective metadata in each RPM.

The SLES 15SP3 build creates an RPM with SP3 metadata and publishes it to `sle-15sp3`:

```bash
Name        : hpe-csm-scripts
Version     : 0.4.1~2~g047236c
Release     : 1
Architecture: noarch
Install Date: (not installed)
Group       : Unspecified
Size        : 175388
License     : HPE Proprietary
Signature   : (none)
Source RPM  : hpe-csm-scripts-0.4.1~2~g047236c-1.src.rpm
Build Date  : Mon 28 Nov 2022 08:08:56 PM UTC
Build Host  : 2a1b1dd024f6
Relocations : (not relocatable)
Vendor      : Hewlett Packard Enterprise Development LP
URL         : https://github.com/Cray-HPE/hpe-csm-scripts.git
Summary     : Installs helper scripts for trouble-shooting or triage.
Description :
Git Repository: hpe-csm-scripts
Git Branch: MTL-1708-SP4
Git Commit Revision: 047236c3
Git Commit Timestamp: Mon Nov 28 14:04:14 2022 -0600
Distribution: SUSE Linux Enterprise Server 15 SP3
```

The SLES 15SP4 build creates an RPM with SP4 metadata, and publishes it to `sle-15sp4`:

```bash
Name        : hpe-csm-scripts
Version     : 0.4.1~2~g047236c
Release     : 1
Architecture: noarch
Install Date: (not installed)
Group       : Unspecified
Size        : 175388
License     : HPE Proprietary
Signature   : (none)
Source RPM  : hpe-csm-scripts-0.4.1~2~g047236c-1.src.rpm
Build Date  : Mon 28 Nov 2022 08:08:56 PM UTC
Build Host  : fddaf9cacb51
Relocations : (not relocatable)
Packager    : https://www.suse.com/
Vendor      : Hewlett Packard Enterprise Development LP
URL         : https://github.com/Cray-HPE/hpe-csm-scripts.git
Summary     : Installs helper scripts for trouble-shooting or triage.
Description :
Git Repository: hpe-csm-scripts
Git Branch: MTL-1708-SP4
Git Commit Revision: 047236c3
Git Commit Timestamp: Mon Nov 28 14:04:14 2022 -0600
Distribution: SUSE Linux Enterprise Server 15 SP4
```

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!---
    Example:
    
    This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
    is resolved and the overall risk of fatal failures is reduced.
    
    -->
