### PR TITLE
CASMHMS-5689 Make sure tclass variable is properly set

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.4.2] - 2022-12-15
+### Changed
+- Fixed a variable that was not being set properly.
+
 ## [0.4.1] - 2022-10-27
 ### Changed
 - Fixed broken HSM CLI call in make_node_groups script.

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.4.2] - 2022-12-15
+## [0.4.3] - 2022-12-15
 ### Changed
 - Fixed a variable that was not being set properly.
 

--- a/scripts/admin_access/set_ssh_keys.py
+++ b/scripts/admin_access/set_ssh_keys.py
@@ -277,8 +277,10 @@ def main():
 
 		# Some components have no class at all.  Rubes!  Try to infer it.
 
-		if not "Class" in comp:
-			if comp['Type'] == "CabinetPDUController":
+		if "Class" in comp:
+			tclass = comp['Class']
+		else:
+			if comp['Type'] == "CabinetPDUController" or comp['Type'] == "CabinetPDUPowerConnector":
 				tclass = "River"
 			else:
 				if debugLevel > 2:


### PR DESCRIPTION
## Summary and Scope

The set_ssh_keys.py script has a bug in it where it does not properly set a variable and ends up skipping all BMCs other than switch controllers when setting ssh keys. This change reworks an if statement to properly set the variable in all cases.

## Issues and Related PRs

* Resolves [CASMHMS-5689](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5689)

## Testing

### Tested on:

  * `hela`

### Test description:

Code changes were done on hela to fix the problem. The script was then copied to the source.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N - N/A
- Was upgrade tested? If not, why? N - Installed via RPM
- Was downgrade tested? If not, why? N - Installed via RPM
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

No known risks.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

