### PR TITLE
CASMHMS-5897 Add PCS to run_hms_ct_tests.sh script

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-(C) Copyright [2021] Hewlett Packard Enterprise Development LP
+(C) Copyright [2021-2023] Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.4.4] - 2023-01-24
+### Changed
+- Added PCS to run_hms_ct_tests.sh script.
+
 ## [0.4.3] - 2022-12-15
 ### Changed
 - Fixed a variable that was not being set properly.


### PR DESCRIPTION
## Summary and Scope

This change adds PCS to the run_hms_ct_tests.sh script so that PCS tests are executed during the HMS section of the CSM health validation steps.

## Issues and Related PRs

* Resolves CASMHMS-5897.

## Testing

### Tested on:

* Wasp running CSM 1.4.0-beta.36

### Test description:

Ran the updated run_hms_ct_tests.sh script. Verified that the new PCS tests executed along with all of the other HMS tests and that the results were processed successfully. Also verified that run_hms_ct_tests.sh could execute only the PCS tests if desired.

## Risks and Mitigations

Low risk, impacts HMS testing only.