### PR TITLE
CASMINST-5858: Rework verify_hsm_discovery.py to support the EX2500 cabinet

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.4.5]
+### Changed
+- The verify_hsm_discovery.py script now properly supports EX2500 cabinets.
+
 ## [0.4.4] - 2023-01-24
 ### Changed
 - Added PCS to run_hms_ct_tests.sh script.


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

Reworked the verify_hsm_discovery.py script to properly supports the EX2500 cabinet. There now exists a single validation function that supports all cabinets types, instead of duplicating logic for each cabinet type. This is useful as the EX2500 cabinet can contain both river and mountain hardware. 

Added some quality of life fixes to reduce the amount of noise in the validation output, to make the interpretation of the output simpler. 
* Only report missing mountain/hill Nodes,NodeBMCs, and RouterBMCs if the slot is actually populated. This is required as SLS assumes fully populated cabinets due to not having a good source of data for this. So only populated slots are considered, and empty slots are ignored. This is a major nuisance if a cabinet is not fully populated as the output of the script will print a line for each node that doesn't actually exist in the system.
* SLS assumes all nodes look like windom nodes when assigning NIDs and creating components. For nodes like Bardpeak/Grizzly Peak/Antero blades where they have a different configuration of node BMCs and nodes on each blade, and false positive warnings are detected for the components that SLS has that don't actually exist on the blade. So these phantom components are ignored in the validation output if the model of blade can be determined, otherwise the old behavior is used.
   *  For example on grizzly peak blades only have 1 BMC `b0` and 2 nodes `b0n0` `b0n1`, and the components  `b1`, `b1n0` and `b1n1` do not exist.
   *   The root issue for this is going to be addresses in CASM-3111
*  Don't emit a warning for the BMC of ncn-m001 missing from HSM, as it is currently expected to not be connected to the HMN network, and therefore cannot be discovered.  
* Don't emit a warning for "Intel CMCs" as those peices of hardware do not really exist in real life. 

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_
Backwards comparable. 

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:
  * Mug
  * Surtur
  * Shandy
  * Baldar
  * Bradi
  * Hela
  * Loki

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

#### Baldar - EX2500 cabinet with mixed river and mountain 
Here is the new output:
```
ncn-m002:~/rsjostrand # ./verify_hsm_discovery.py 
HSM Cabinet Summary
===================
x8000 (Hill - EX2500)
  Discovered Nodes:          30
  Discovered Node BMCs:      17
  Discovered Router BMCs:     0
  Discovered Chassis BMCs:    1
  Discovered Cab PDU Ctlrs:   0
  Discovered CMCs:            0
  Compute Module slots
    Populated:   6
    Empty:       2
  Router Module slots
    Populated:   4
    Empty:       4

River Cabinet Checks
============================
None Found.

Mountain/Hill Cabinet Checks
============================
None Found.

EX2500 Cabinet Checks
============================
Checking cabinet x8000
x8000 (Hill - EX2500)
  ChassisBMCs: PASS
  Nodes: FAIL
    - x8000c4s32b0n0 (Application, NID N/A, Alias uan01) - Not found in HSM Components.
  NodeBMCs: FAIL
    - x8000c4s32b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
  RouterBMCs: PASS
  CMCs: PASS
  CabinetPDUControllers: FAIL
    - x8000m0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x8000m1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
```

Here is the output of the original script:
```
ncn-m002:~/rsjostrand # /opt/cray/csm/scripts/hms_verification/verify_hsm_discovery.py 
HSM Cabinet Summary
===================
x8000 (Hill)
  Discovered Nodes:          30
  Discovered Node BMCs:      17
  Discovered Router BMCs:     0
  Discovered Chassis BMCs:    1

River Cabinet Checks
====================

Mountain/Hill Cabinet Checks
============================
x8000 (Hill)
  ChassisBMCs: PASS
Traceback (most recent call last):
  File "/opt/cray/csm/scripts/hms_verification/verify_hsm_discovery.py", line 648, in <module>
    ret = main()
  File "/opt/cray/csm/scripts/hms_verification/verify_hsm_discovery.py", line 639, in main
    numErrs += genMountainDetails(slsData, compData, rfepData)
  File "/opt/cray/csm/scripts/hms_verification/verify_hsm_discovery.py", line 542, in genMountainDetails
    comp['ExtraProperties']['NID']))
KeyError: 'NID'
```

#### Bradi - 1 River cabinet and 1 EX2500 with 3 chassis
Here is the new output:
```
[~/Documents/Github/hpe-csm-scripts.back]$ ssh root@bradi-ncn-m001.hpc.amslabs.hpecorp.net                                                                                                [CASMINST-5858]
Password: 
Last login: Fri Jan 27 20:45:05 2023 from 16.99.209.239
ncn-m001:~ # /tmp/verify_hsm_discovery.py 
HSM Cabinet Summary
===================
x3000 (River)
  Discovered Nodes:          15 (10 Mgmt, 1 Application, 4 Compute)
  Discovered Node BMCs:      14
  Discovered Router BMCs:     1
  Discovered Chassis BMCs:    0
  Discovered Cab PDU Ctlrs:   0
  Discovered CMCs:            1
x9000 (Hill - EX2500)
  Discovered Nodes:          52
  Discovered Node BMCs:      24
  Discovered Router BMCs:    12
  Discovered Chassis BMCs:    3
  Discovered Cab PDU Ctlrs:   0
  Discovered CMCs:            0
  Compute Module slots
    Populated:  15
    Empty:       9
  Router Module slots
    Populated:  12
    Empty:      12

River Cabinet Checks
============================
Checking cabinet x3000
x3000 (River)
  Nodes: PASS
  NodeBMCs: PASS
  RouterBMCs: PASS
  CMCs: PASS
  CabinetPDUControllers: FAIL
    - x3000m1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x3000m0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.

Mountain/Hill Cabinet Checks
============================
None Found.

EX2500 Cabinet Checks
============================
Checking cabinet x9000
x9000 (Hill - EX2500)
  ChassisBMCs: PASS
  Nodes: PASS
  NodeBMCs: PASS
  RouterBMCs: PASS
  CMCs: PASS
  CabinetPDUControllers: PASS
```
Here is the output of the original script:
```
ncn-m001:~ # /opt/cray/csm/scripts/hms_verification/verify_hsm_discovery.py 
HSM Cabinet Summary
===================
x3000 (River)
  Discovered Nodes:          15 (10 Mgmt, 1 Application, 4 Compute)
  Discovered Node BMCs:      15
  Discovered Router BMCs:     1
  Discovered Chassis BMCs:    0
  Discovered Cab PDU Ctlrs:   0
x9000 (Hill)
  Discovered Nodes:          52
  Discovered Node BMCs:      24
  Discovered Router BMCs:    12
  Discovered Chassis BMCs:    3

River Cabinet Checks
====================
x3000
  Nodes: PASS
  NodeBMCs: WARNING
    - x3000c0s1b0 - Not found in HSM Components; No mgmt port connection; BMC of mgmt node ncn-m001.
  RouterBMCs: PASS
  ChassisBMCs/CMCs: PASS
  CabinetPDUControllers: WARNING
    - x3000m1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x3000m0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.

Mountain/Hill Cabinet Checks
============================
x9000 (Hill)
  ChassisBMCs: PASS
  Nodes: WARNING
    - x9000c2s5b1n1 (Compute, NID 1087) - Not found in HSM Components.
    - x9000c2s7b1n0 (Compute, NID 1094) - Not found in HSM Components.
    - x9000c2s3b0n1 (Compute, NID 1077) - Not found in HSM Components.
    - x9000c0s0b1n0 (Compute, NID 1002) - Not found in HSM Components.
    - x9000c0s2b1n1 (Compute, NID 1011) - Not found in HSM Components.
    - x9000c2s3b1n1 (Compute, NID 1079) - Not found in HSM Components.
    - x9000c2s4b1n1 (Compute, NID 1083) - Not found in HSM Components.
    - x9000c2s5b0n0 (Compute, NID 1084) - Not found in HSM Components.
    - x9000c2s2b0n1 (Compute, NID 1073) - Not found in HSM Components.
    - x9000c2s6b1n1 (Compute, NID 1091) - Not found in HSM Components.
    - x9000c2s4b1n0 (Compute, NID 1082) - Not found in HSM Components.
    - x9000c2s6b1n0 (Compute, NID 1090) - Not found in HSM Components.
    - x9000c0s7b1n1 (Compute, NID 1031) - Not found in HSM Components.
    - x9000c1s5b1n0 (Compute, NID 1054) - Not found in HSM Components.
    - x9000c2s4b0n0 (Compute, NID 1080) - Not found in HSM Components.
    - x9000c2s7b0n1 (Compute, NID 1093) - Not found in HSM Components.
    - x9000c0s2b1n0 (Compute, NID 1010) - Not found in HSM Components.
    - x9000c1s5b0n0 (Compute, NID 1052) - Not found in HSM Components.
    - x9000c2s5b0n1 (Compute, NID 1085) - Not found in HSM Components.
    - x9000c1s2b0n1 (Compute, NID 1041) - Not found in HSM Components.
    - x9000c0s1b1n1 (Compute, NID 1007) - Not found in HSM Components.
    - x9000c1s5b0n1 (Compute, NID 1053) - Not found in HSM Components.
    - x9000c2s5b1n0 (Compute, NID 1086) - Not found in HSM Components.
    - x9000c0s1b0n1 (Compute, NID 1005) - Not found in HSM Components.
    - x9000c2s6b0n0 (Compute, NID 1088) - Not found in HSM Components.
    - x9000c0s0b0n1 (Compute, NID 1001) - Not found in HSM Components.
    - x9000c2s6b0n1 (Compute, NID 1089) - Not found in HSM Components.
    - x9000c2s3b0n0 (Compute, NID 1076) - Not found in HSM Components.
    - x9000c0s0b0n0 (Compute, NID 1000) - Not found in HSM Components.
    - x9000c2s2b1n0 (Compute, NID 1074) - Not found in HSM Components.
    - x9000c0s7b1n0 (Compute, NID 1030) - Not found in HSM Components.
    - x9000c1s2b1n1 (Compute, NID 1043) - Not found in HSM Components.
    - x9000c2s7b1n1 (Compute, NID 1095) - Not found in HSM Components.
    - x9000c1s1b0n1 (Compute, NID 1037) - Not found in HSM Components.
    - x9000c2s2b1n1 (Compute, NID 1075) - Not found in HSM Components.
    - x9000c1s1b1n1 (Compute, NID 1039) - Not found in HSM Components.
    - x9000c2s7b0n0 (Compute, NID 1092) - Not found in HSM Components.
    - x9000c2s2b0n0 (Compute, NID 1072) - Not found in HSM Components.
    - x9000c2s4b0n1 (Compute, NID 1081) - Not found in HSM Components.
    - x9000c0s0b1n1 (Compute, NID 1003) - Not found in HSM Components.
    - x9000c0s1b1n0 (Compute, NID 1006) - Not found in HSM Components.
    - x9000c2s3b1n0 (Compute, NID 1078) - Not found in HSM Components.
    - x9000c0s1b0n0 (Compute, NID 1004) - Not found in HSM Components.
    - x9000c1s5b1n1 (Compute, NID 1055) - Not found in HSM Components.
  NodeBMCs: WARNING
    - x9000c2s5b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x9000c2s7b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x9000c2s3b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x9000c0s0b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x9000c0s2b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x9000c2s3b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x9000c2s4b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x9000c2s5b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x9000c2s2b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x9000c2s6b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x9000c0s7b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x9000c1s5b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x9000c2s4b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x9000c2s7b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x9000c1s5b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x9000c0s1b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x9000c0s1b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x9000c2s6b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x9000c0s0b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x9000c2s2b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
  RouterBMCs: PASS
```
#### Hela - 1 River cabinet with 1 Mountain cabinet
Here is the new output:
```
ncn-m001:/mnt/developer/rsjostrand # ./verify_hsm_discovery.py 
HSM Cabinet Summary
===================
x1000 (Mountain)
  Discovered Nodes:          16
  Discovered Node BMCs:       5
  Discovered Router BMCs:    16
  Discovered Chassis BMCs:    8
  Compute Module slots
    Populated:   5
    Empty:      59
  Router Module slots
    Populated:  16
    Empty:      48
x3000 (River)
  Discovered Nodes:          12 (10 Mgmt, 2 Application, 0 Compute)
  Discovered Node BMCs:      11
  Discovered Router BMCs:     2
  Discovered Chassis BMCs:    0
  Discovered Cab PDU Ctlrs:   2
  Discovered CMCs:            0

River Cabinet Checks
============================
Checking cabinet x3000
x3000 (River)
  Nodes: PASS
  NodeBMCs: PASS
  RouterBMCs: PASS
  CMCs: PASS
  CabinetPDUControllers: PASS

Mountain/Hill Cabinet Checks
============================
Checking cabinet x1000
x1000 (Mountain)
  ChassisBMCs: PASS
  Nodes: PASS
  NodeBMCs: PASS
  RouterBMCs: PASS

EX2500 Cabinet Checks
============================
None Found.

```

Here is the output of the original script:
```
ncn-m001:/mnt/developer/rsjostrand # /opt/cray/csm/scripts/hms_verification/verify_hsm_discovery.py 
HSM Cabinet Summary
===================
x1000 (Mountain)
  Discovered Nodes:          16
  Discovered Node BMCs:       5
  Discovered Router BMCs:    16
  Discovered Chassis BMCs:    8
x3000 (River)
  Discovered Nodes:          12 (10 Mgmt, 2 Application, 0 Compute)
  Discovered Node BMCs:      11
  Discovered Router BMCs:     2
  Discovered Chassis BMCs:    0
  Discovered Cab PDU Ctlrs:   2

River Cabinet Checks
====================
x3000
  Nodes: PASS
  NodeBMCs: WARNING
    - x3000c0s1b0 - Not found in HSM Components; No mgmt port connection; BMC of mgmt node ncn-m001.
  RouterBMCs: PASS
  ChassisBMCs/CMCs: PASS
  CabinetPDUControllers: PASS

Mountain/Hill Cabinet Checks
============================
x1000 (Mountain)
  ChassisBMCs: PASS
  Nodes: WARNING
    - x1000c1s5b0n1 (Compute, NID 1053) - Not found in HSM Components.
    - x1000c2s3b0n0 (Compute, NID 1076) - Not found in HSM Components.
    - x1000c2s7b1n1 (Compute, NID 1095) - Not found in HSM Components.
    - x1000c4s0b1n1 (Compute, NID 1131) - Not found in HSM Components.
    - x1000c6s4b1n0 (Compute, NID 1210) - Not found in HSM Components.
    - x1000c0s4b1n1 (Compute, NID 1019) - Not found in HSM Components.
    - x1000c0s6b0n0 (Compute, NID 1024) - Not found in HSM Components.
    - x1000c6s0b1n0 (Compute, NID 1194) - Not found in HSM Components.
    - x1000c7s0b1n0 (Compute, NID 1226) - Not found in HSM Components.
    - x1000c0s5b1n1 (Compute, NID 1023) - Not found in HSM Components.
    - x1000c2s5b1n0 (Compute, NID 1086) - Not found in HSM Components.
    - x1000c4s2b1n0 (Compute, NID 1138) - Not found in HSM Components.
    - x1000c4s6b1n1 (Compute, NID 1155) - Not found in HSM Components.
    - x1000c5s6b0n1 (Compute, NID 1185) - Not found in HSM Components.
    - x1000c7s6b0n1 (Compute, NID 1249) - Not found in HSM Components.
    - x1000c2s0b0n0 (Compute, NID 1064) - Not found in HSM Components.
    - x1000c3s6b1n0 (Compute, NID 1122) - Not found in HSM Components.
    - x1000c3s6b0n0 (Compute, NID 1120) - Not found in HSM Components.
    - x1000c2s4b0n0 (Compute, NID 1080) - Not found in HSM Components.
    - x1000c7s4b1n0 (Compute, NID 1242) - Not found in HSM Components.
    - x1000c0s2b0n1 (Compute, NID 1009) - Not found in HSM Components.
    - x1000c1s7b1n0 (Compute, NID 1062) - Not found in HSM Components.
    - x1000c4s3b1n1 (Compute, NID 1143) - Not found in HSM Components.
    - x1000c7s2b0n0 (Compute, NID 1232) - Not found in HSM Components.
    - x1000c1s0b0n0 (Compute, NID 1032) - Not found in HSM Components.
    - x1000c2s3b1n1 (Compute, NID 1079) - Not found in HSM Components.
    - x1000c4s2b0n1 (Compute, NID 1137) - Not found in HSM Components.
    - x1000c1s2b0n1 (Compute, NID 1041) - Not found in HSM Components.
    - x1000c3s7b1n0 (Compute, NID 1126) - Not found in HSM Components.
    - x1000c4s0b0n0 (Compute, NID 1128) - Not found in HSM Components.
    - x1000c6s2b1n0 (Compute, NID 1202) - Not found in HSM Components.
    - x1000c3s1b0n1 (Compute, NID 1101) - Not found in HSM Components.
    - x1000c3s3b1n0 (Compute, NID 1110) - Not found in HSM Components.
    - x1000c5s5b1n1 (Compute, NID 1183) - Not found in HSM Components.
    - x1000c6s6b0n1 (Compute, NID 1217) - Not found in HSM Components.
    - x1000c1s3b0n1 (Compute, NID 1045) - Not found in HSM Components.
    - x1000c1s5b1n0 (Compute, NID 1054) - Not found in HSM Components.
    - x1000c1s7b1n1 (Compute, NID 1063) - Not found in HSM Components.
    - x1000c3s5b0n1 (Compute, NID 1117) - Not found in HSM Components.
    - x1000c4s3b0n1 (Compute, NID 1141) - Not found in HSM Components.
    - x1000c5s6b1n1 (Compute, NID 1187) - Not found in HSM Components.
    - x1000c5s7b0n1 (Compute, NID 1189) - Not found in HSM Components.
    - x1000c0s3b1n1 (Compute, NID 1015) - Not found in HSM Components.
    - x1000c1s4b1n0 (Compute, NID 1050) - Not found in HSM Components.
    - x1000c5s7b0n0 (Compute, NID 1188) - Not found in HSM Components.
    - x1000c0s3b1n0 (Compute, NID 1014) - Not found in HSM Components.
    - x1000c2s5b0n1 (Compute, NID 1085) - Not found in HSM Components.
    - x1000c0s5b0n1 (Compute, NID 1021) - Not found in HSM Components.
    - x1000c1s6b1n0 (Compute, NID 1058) - Not found in HSM Components.
    - x1000c1s4b0n1 (Compute, NID 1049) - Not found in HSM Components.
    - x1000c3s3b0n1 (Compute, NID 1109) - Not found in HSM Components.
    - x1000c7s7b1n1 (Compute, NID 1255) - Not found in HSM Components.
    - x1000c0s5b0n0 (Compute, NID 1020) - Not found in HSM Components.
    - x1000c1s3b1n1 (Compute, NID 1047) - Not found in HSM Components.
    - x1000c2s4b0n1 (Compute, NID 1081) - Not found in HSM Components.
    - x1000c4s4b1n1 (Compute, NID 1147) - Not found in HSM Components.
    - x1000c4s7b0n0 (Compute, NID 1156) - Not found in HSM Components.
    - x1000c7s1b0n1 (Compute, NID 1229) - Not found in HSM Components.
    - x1000c0s4b0n0 (Compute, NID 1016) - Not found in HSM Components.
    - x1000c3s2b0n1 (Compute, NID 1105) - Not found in HSM Components.
    - x1000c3s4b1n1 (Compute, NID 1115) - Not found in HSM Components.
    - x1000c4s3b0n0 (Compute, NID 1140) - Not found in HSM Components.
    - x1000c7s0b0n1 (Compute, NID 1225) - Not found in HSM Components.
    - x1000c2s5b0n0 (Compute, NID 1084) - Not found in HSM Components.
    - x1000c2s7b0n0 (Compute, NID 1092) - Not found in HSM Components.
    - x1000c5s5b0n0 (Compute, NID 1180) - Not found in HSM Components.
    - x1000c6s3b0n0 (Compute, NID 1204) - Not found in HSM Components.
    - x1000c7s1b1n1 (Compute, NID 1231) - Not found in HSM Components.
    - x1000c0s6b1n0 (Compute, NID 1026) - Not found in HSM Components.
    - x1000c2s6b1n0 (Compute, NID 1090) - Not found in HSM Components.
    - x1000c4s1b1n1 (Compute, NID 1135) - Not found in HSM Components.
    - x1000c6s0b0n0 (Compute, NID 1192) - Not found in HSM Components.
    - x1000c7s5b0n1 (Compute, NID 1245) - Not found in HSM Components.
    - x1000c3s1b0n0 (Compute, NID 1100) - Not found in HSM Components.
    - x1000c3s6b1n1 (Compute, NID 1123) - Not found in HSM Components.
    - x1000c3s5b1n1 (Compute, NID 1119) - Not found in HSM Components.
    - x1000c2s6b1n1 (Compute, NID 1091) - Not found in HSM Components.
    - x1000c3s4b0n0 (Compute, NID 1112) - Not found in HSM Components.
    - x1000c5s6b1n0 (Compute, NID 1186) - Not found in HSM Components.
    - x1000c6s1b1n1 (Compute, NID 1199) - Not found in HSM Components.
    - x1000c6s2b0n0 (Compute, NID 1200) - Not found in HSM Components.
    - x1000c1s3b1n0 (Compute, NID 1046) - Not found in HSM Components.
    - x1000c2s2b1n1 (Compute, NID 1075) - Not found in HSM Components.
    - x1000c2s6b0n0 (Compute, NID 1088) - Not found in HSM Components.
    - x1000c3s0b1n0 (Compute, NID 1098) - Not found in HSM Components.
    - x1000c0s0b1n1 (Compute, NID 1003) - Not found in HSM Components.
    - x1000c2s2b0n1 (Compute, NID 1073) - Not found in HSM Components.
    - x1000c6s6b1n1 (Compute, NID 1219) - Not found in HSM Components.
    - x1000c0s2b1n1 (Compute, NID 1011) - Not found in HSM Components.
    - x1000c5s1b1n0 (Compute, NID 1166) - Not found in HSM Components.
    - x1000c3s2b0n0 (Compute, NID 1104) - Not found in HSM Components.
    - x1000c3s6b0n1 (Compute, NID 1121) - Not found in HSM Components.
    - x1000c5s1b1n1 (Compute, NID 1167) - Not found in HSM Components.
    - x1000c6s1b1n0 (Compute, NID 1198) - Not found in HSM Components.
    - x1000c6s4b0n0 (Compute, NID 1208) - Not found in HSM Components.
    - x1000c3s1b1n0 (Compute, NID 1102) - Not found in HSM Components.
    - x1000c6s4b0n1 (Compute, NID 1209) - Not found in HSM Components.
    - x1000c0s7b1n0 (Compute, NID 1030) - Not found in HSM Components.
    - x1000c6s3b1n0 (Compute, NID 1206) - Not found in HSM Components.
    - x1000c3s7b1n1 (Compute, NID 1127) - Not found in HSM Components.
    - x1000c6s2b0n1 (Compute, NID 1201) - Not found in HSM Components.
    - x1000c6s3b0n1 (Compute, NID 1205) - Not found in HSM Components.
    - x1000c6s7b1n0 (Compute, NID 1222) - Not found in HSM Components.
    - x1000c7s4b1n1 (Compute, NID 1243) - Not found in HSM Components.
    - x1000c1s5b0n0 (Compute, NID 1052) - Not found in HSM Components.
    - x1000c3s2b1n1 (Compute, NID 1107) - Not found in HSM Components.
    - x1000c1s7b0n0 (Compute, NID 1060) - Not found in HSM Components.
    - x1000c2s7b0n1 (Compute, NID 1093) - Not found in HSM Components.
    - x1000c7s0b1n1 (Compute, NID 1227) - Not found in HSM Components.
    - x1000c1s2b0n0 (Compute, NID 1040) - Not found in HSM Components.
    - x1000c4s2b1n1 (Compute, NID 1139) - Not found in HSM Components.
    - x1000c5s5b1n0 (Compute, NID 1182) - Not found in HSM Components.
    - x1000c6s0b0n1 (Compute, NID 1193) - Not found in HSM Components.
    - x1000c6s1b0n0 (Compute, NID 1196) - Not found in HSM Components.
    - x1000c6s6b0n0 (Compute, NID 1216) - Not found in HSM Components.
    - x1000c7s1b0n0 (Compute, NID 1228) - Not found in HSM Components.
    - x1000c0s1b0n1 (Compute, NID 1005) - Not found in HSM Components.
    - x1000c0s7b0n0 (Compute, NID 1028) - Not found in HSM Components.
    - x1000c7s5b1n0 (Compute, NID 1246) - Not found in HSM Components.
    - x1000c0s0b1n0 (Compute, NID 1002) - Not found in HSM Components.
    - x1000c4s6b0n1 (Compute, NID 1153) - Not found in HSM Components.
    - x1000c2s1b1n1 (Compute, NID 1071) - Not found in HSM Components.
    - x1000c6s7b0n1 (Compute, NID 1221) - Not found in HSM Components.
    - x1000c1s1b1n0 (Compute, NID 1038) - Not found in HSM Components.
    - x1000c1s2b1n0 (Compute, NID 1042) - Not found in HSM Components.
    - x1000c1s1b0n0 (Compute, NID 1036) - Not found in HSM Components.
    - x1000c2s0b1n1 (Compute, NID 1067) - Not found in HSM Components.
    - x1000c3s0b0n1 (Compute, NID 1097) - Not found in HSM Components.
    - x1000c3s7b0n1 (Compute, NID 1125) - Not found in HSM Components.
    - x1000c6s4b1n1 (Compute, NID 1211) - Not found in HSM Components.
    - x1000c0s1b1n1 (Compute, NID 1007) - Not found in HSM Components.
    - x1000c6s0b1n1 (Compute, NID 1195) - Not found in HSM Components.
    - x1000c6s2b1n1 (Compute, NID 1203) - Not found in HSM Components.
    - x1000c7s2b1n0 (Compute, NID 1234) - Not found in HSM Components.
    - x1000c7s3b0n0 (Compute, NID 1236) - Not found in HSM Components.
    - x1000c1s3b0n0 (Compute, NID 1044) - Not found in HSM Components.
    - x1000c1s7b0n1 (Compute, NID 1061) - Not found in HSM Components.
    - x1000c2s4b1n1 (Compute, NID 1083) - Not found in HSM Components.
    - x1000c3s0b1n1 (Compute, NID 1099) - Not found in HSM Components.
    - x1000c4s7b1n1 (Compute, NID 1159) - Not found in HSM Components.
    - x1000c6s5b0n0 (Compute, NID 1212) - Not found in HSM Components.
    - x1000c6s6b1n0 (Compute, NID 1218) - Not found in HSM Components.
    - x1000c1s4b1n1 (Compute, NID 1051) - Not found in HSM Components.
    - x1000c2s2b0n0 (Compute, NID 1072) - Not found in HSM Components.
    - x1000c7s3b0n1 (Compute, NID 1237) - Not found in HSM Components.
    - x1000c6s5b0n1 (Compute, NID 1213) - Not found in HSM Components.
    - x1000c4s6b0n0 (Compute, NID 1152) - Not found in HSM Components.
    - x1000c7s2b0n1 (Compute, NID 1233) - Not found in HSM Components.
    - x1000c1s0b1n1 (Compute, NID 1035) - Not found in HSM Components.
    - x1000c4s0b1n0 (Compute, NID 1130) - Not found in HSM Components.
    - x1000c1s1b1n1 (Compute, NID 1039) - Not found in HSM Components.
    - x1000c5s0b1n1 (Compute, NID 1163) - Not found in HSM Components.
    - x1000c7s5b0n0 (Compute, NID 1244) - Not found in HSM Components.
    - x1000c0s1b0n0 (Compute, NID 1004) - Not found in HSM Components.
    - x1000c0s7b0n1 (Compute, NID 1029) - Not found in HSM Components.
    - x1000c5s7b1n1 (Compute, NID 1191) - Not found in HSM Components.
    - x1000c3s2b1n0 (Compute, NID 1106) - Not found in HSM Components.
    - x1000c0s6b1n1 (Compute, NID 1027) - Not found in HSM Components.
    - x1000c7s0b0n0 (Compute, NID 1224) - Not found in HSM Components.
    - x1000c0s0b0n0 (Compute, NID 1000) - Not found in HSM Components.
    - x1000c0s6b0n1 (Compute, NID 1025) - Not found in HSM Components.
    - x1000c3s3b0n0 (Compute, NID 1108) - Not found in HSM Components.
    - x1000c7s7b1n0 (Compute, NID 1254) - Not found in HSM Components.
    - x1000c0s3b0n0 (Compute, NID 1012) - Not found in HSM Components.
    - x1000c2s2b1n0 (Compute, NID 1074) - Not found in HSM Components.
    - x1000c6s7b0n0 (Compute, NID 1220) - Not found in HSM Components.
    - x1000c7s3b1n1 (Compute, NID 1239) - Not found in HSM Components.
    - x1000c3s4b1n0 (Compute, NID 1114) - Not found in HSM Components.
    - x1000c4s3b1n0 (Compute, NID 1142) - Not found in HSM Components.
    - x1000c4s5b0n1 (Compute, NID 1149) - Not found in HSM Components.
    - x1000c6s1b0n1 (Compute, NID 1197) - Not found in HSM Components.
    - x1000c3s1b1n1 (Compute, NID 1103) - Not found in HSM Components.
    - x1000c3s7b0n0 (Compute, NID 1124) - Not found in HSM Components.
    - x1000c4s5b0n0 (Compute, NID 1148) - Not found in HSM Components.
    - x1000c4s7b1n0 (Compute, NID 1158) - Not found in HSM Components.
    - x1000c7s2b1n1 (Compute, NID 1235) - Not found in HSM Components.
    - x1000c7s7b0n0 (Compute, NID 1252) - Not found in HSM Components.
    - x1000c3s5b0n0 (Compute, NID 1116) - Not found in HSM Components.
    - x1000c4s4b0n1 (Compute, NID 1145) - Not found in HSM Components.
    - x1000c0s1b1n0 (Compute, NID 1006) - Not found in HSM Components.
    - x1000c2s1b0n1 (Compute, NID 1069) - Not found in HSM Components.
    - x1000c0s2b0n0 (Compute, NID 1008) - Not found in HSM Components.
    - x1000c1s0b0n1 (Compute, NID 1033) - Not found in HSM Components.
    - x1000c6s5b1n0 (Compute, NID 1214) - Not found in HSM Components.
    - x1000c1s0b1n0 (Compute, NID 1034) - Not found in HSM Components.
    - x1000c1s4b0n0 (Compute, NID 1048) - Not found in HSM Components.
    - x1000c4s0b0n1 (Compute, NID 1129) - Not found in HSM Components.
    - x1000c4s1b1n0 (Compute, NID 1134) - Not found in HSM Components.
    - x1000c4s5b1n0 (Compute, NID 1150) - Not found in HSM Components.
    - x1000c6s5b1n1 (Compute, NID 1215) - Not found in HSM Components.
    - x1000c7s6b1n0 (Compute, NID 1250) - Not found in HSM Components.
    - x1000c7s6b1n1 (Compute, NID 1251) - Not found in HSM Components.
    - x1000c0s3b0n1 (Compute, NID 1013) - Not found in HSM Components.
    - x1000c1s5b1n1 (Compute, NID 1055) - Not found in HSM Components.
    - x1000c7s7b0n1 (Compute, NID 1253) - Not found in HSM Components.
    - x1000c5s0b1n0 (Compute, NID 1162) - Not found in HSM Components.
    - x1000c7s5b1n1 (Compute, NID 1247) - Not found in HSM Components.
    - x1000c4s4b0n0 (Compute, NID 1144) - Not found in HSM Components.
    - x1000c4s5b1n1 (Compute, NID 1151) - Not found in HSM Components.
    - x1000c3s0b0n0 (Compute, NID 1096) - Not found in HSM Components.
    - x1000c2s7b1n0 (Compute, NID 1094) - Not found in HSM Components.
    - x1000c0s4b1n0 (Compute, NID 1018) - Not found in HSM Components.
    - x1000c1s2b1n1 (Compute, NID 1043) - Not found in HSM Components.
    - x1000c1s6b1n1 (Compute, NID 1059) - Not found in HSM Components.
    - x1000c2s1b0n0 (Compute, NID 1068) - Not found in HSM Components.
    - x1000c0s4b0n1 (Compute, NID 1017) - Not found in HSM Components.
    - x1000c5s6b0n0 (Compute, NID 1184) - Not found in HSM Components.
    - x1000c2s0b1n0 (Compute, NID 1066) - Not found in HSM Components.
    - x1000c2s5b1n1 (Compute, NID 1087) - Not found in HSM Components.
    - x1000c2s6b0n1 (Compute, NID 1089) - Not found in HSM Components.
    - x1000c6s3b1n1 (Compute, NID 1207) - Not found in HSM Components.
    - x1000c0s2b1n0 (Compute, NID 1010) - Not found in HSM Components.
    - x1000c5s5b0n1 (Compute, NID 1181) - Not found in HSM Components.
    - x1000c1s1b0n1 (Compute, NID 1037) - Not found in HSM Components.
    - x1000c3s5b1n0 (Compute, NID 1118) - Not found in HSM Components.
    - x1000c4s4b1n0 (Compute, NID 1146) - Not found in HSM Components.
    - x1000c0s7b1n1 (Compute, NID 1031) - Not found in HSM Components.
    - x1000c4s7b0n1 (Compute, NID 1157) - Not found in HSM Components.
    - x1000c2s3b1n0 (Compute, NID 1078) - Not found in HSM Components.
    - x1000c4s1b0n0 (Compute, NID 1132) - Not found in HSM Components.
    - x1000c5s7b1n0 (Compute, NID 1190) - Not found in HSM Components.
    - x1000c2s0b0n1 (Compute, NID 1065) - Not found in HSM Components.
    - x1000c2s1b1n0 (Compute, NID 1070) - Not found in HSM Components.
    - x1000c4s2b0n0 (Compute, NID 1136) - Not found in HSM Components.
    - x1000c1s6b0n1 (Compute, NID 1057) - Not found in HSM Components.
    - x1000c4s1b0n1 (Compute, NID 1133) - Not found in HSM Components.
    - x1000c3s3b1n1 (Compute, NID 1111) - Not found in HSM Components.
    - x1000c6s7b1n1 (Compute, NID 1223) - Not found in HSM Components.
    - x1000c7s4b0n0 (Compute, NID 1240) - Not found in HSM Components.
    - x1000c7s4b0n1 (Compute, NID 1241) - Not found in HSM Components.
    - x1000c0s5b1n0 (Compute, NID 1022) - Not found in HSM Components.
    - x1000c2s4b1n0 (Compute, NID 1082) - Not found in HSM Components.
    - x1000c7s1b1n0 (Compute, NID 1230) - Not found in HSM Components.
    - x1000c3s4b0n1 (Compute, NID 1113) - Not found in HSM Components.
    - x1000c7s3b1n0 (Compute, NID 1238) - Not found in HSM Components.
    - x1000c7s6b0n0 (Compute, NID 1248) - Not found in HSM Components.
    - x1000c2s3b0n1 (Compute, NID 1077) - Not found in HSM Components.
    - x1000c4s6b1n0 (Compute, NID 1154) - Not found in HSM Components.
    - x1000c0s0b0n1 (Compute, NID 1001) - Not found in HSM Components.
    - x1000c1s6b0n0 (Compute, NID 1056) - Not found in HSM Components.
  NodeBMCs: WARNING
    - x1000c1s5b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c2s3b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c2s7b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c4s0b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c6s4b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c0s4b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c0s6b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c6s0b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c7s0b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c0s5b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c2s5b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c4s2b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c4s6b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c5s6b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c7s6b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c2s0b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c3s6b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c3s6b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c2s4b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c7s4b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c0s2b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c1s7b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c4s3b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c7s2b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c1s0b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c2s3b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c4s2b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c1s2b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c3s7b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c4s0b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c6s2b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c3s1b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c3s3b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c5s5b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c6s6b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c1s3b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c1s5b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c3s5b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c4s3b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c5s6b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c5s7b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c0s3b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c1s4b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c2s5b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c0s5b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c1s6b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c1s4b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c3s3b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c7s7b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c1s3b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c4s4b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c4s7b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c7s1b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c0s4b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c3s2b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c3s4b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c7s0b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c2s7b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c5s5b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c6s3b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c7s1b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c0s6b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c2s6b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c4s1b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c6s0b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c7s5b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c3s5b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c3s4b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c6s1b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c6s2b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c2s2b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c2s6b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c3s0b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c0s0b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c2s2b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c6s6b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c0s2b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c5s1b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c6s4b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c3s1b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c0s7b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c6s3b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c6s7b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c3s2b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c1s7b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c6s1b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c0s1b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c0s7b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c7s5b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c4s6b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c2s1b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c6s7b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c1s1b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c1s2b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c1s1b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c2s0b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c3s0b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c3s7b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c0s1b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c7s2b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c7s3b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c2s4b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c4s7b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c6s5b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c1s0b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c5s0b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c5s7b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c0s0b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c0s3b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c7s3b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c4s5b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c7s7b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c4s4b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c2s1b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c6s5b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c4s5b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c7s6b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c4s1b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c1s6b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x1000c7s4b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
  RouterBMCs: PASS

```
#### Loki - 1 River cabinet and 1 Hill cabinet
Here is the new output:
```
HSM Cabinet Summary
===================
x3000 (River)
  Discovered Nodes:          14 (9 Mgmt, 5 Application, 0 Compute)
  Discovered Node BMCs:      13
  Discovered Router BMCs:     1
  Discovered Chassis BMCs:    0
  Discovered Cab PDU Ctlrs:   2
  Discovered CMCs:            0
x9000 (Hill)
  Discovered Nodes:          24
  Discovered Node BMCs:      11
  Discovered Router BMCs:     8
  Discovered Chassis BMCs:    2
  Compute Module slots
    Populated:   7
    Empty:       9
  Router Module slots
    Populated:   8
    Empty:       8

River Cabinet Checks
============================
Checking cabinet x3000
x3000 (River)
  Nodes: FAIL
    - x3000c0s16b0n0 (Application, NID N/A, Alias gateway01) - Not found in HSM Components.
  NodeBMCs: FAIL
    - x3000c0s16b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints; No mgmt port connection.
  RouterBMCs: PASS
  CMCs: PASS
  CabinetPDUControllers: PASS

Mountain/Hill Cabinet Checks
============================
Checking cabinet x9000
x9000 (Hill)
  ChassisBMCs: PASS
  Nodes: PASS
  NodeBMCs: PASS
  RouterBMCs: PASS

EX2500 Cabinet Checks
============================
None Found.
```

Here is the output of the original script:
```
ncn-m001:/mnt/developer/rsjostrand # /opt/cray/csm/scripts/hms_verification/verify_hsm_discovery.py 
HSM Cabinet Summary
===================
x3000 (River)
  Discovered Nodes:          14 (9 Mgmt, 5 Application, 0 Compute)
  Discovered Node BMCs:      13
  Discovered Router BMCs:     1
  Discovered Chassis BMCs:    0
  Discovered Cab PDU Ctlrs:   2
x9000 (Hill)
  Discovered Nodes:          24
  Discovered Node BMCs:      11
  Discovered Router BMCs:     8
  Discovered Chassis BMCs:    2

River Cabinet Checks
====================
x3000
  Nodes: FAIL
    - x3000c0s16b0n0 (Application, NID N/A) - Not found in HSM Components.
  NodeBMCs: FAIL
    - x3000c0s16b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints; No mgmt port connection.
  NodeBMCs: WARNING
    - x3000c0s1b0 - Not found in HSM Components; No mgmt port connection; BMC of mgmt node ncn-m001.
  RouterBMCs: PASS
  ChassisBMCs/CMCs: PASS
  CabinetPDUControllers: PASS

Mountain/Hill Cabinet Checks
============================
x9000 (Hill)
  ChassisBMCs: PASS
  Nodes: WARNING
    - x9000c1s6b0n1 (Compute, NID 1025) - Not found in HSM Components.
    - x9000c3s0b0n2 (Compute, NID 1034) - Not found in HSM Components.
    - x9000c1s0b1n1 (Compute, NID 1003) - Not found in HSM Components.
    - x9000c3s0b0n3 (Compute, NID 1035) - Not found in HSM Components.
    - x9000c3s3b1n1 (Compute, NID 1047) - Not found in HSM Components.
    - x9000c3s0b0n0 (Compute, NID 1032) - Not found in HSM Components.
    - x9000c3s1b0n0 (Compute, NID 1036) - Not found in HSM Components.
    - x9000c3s1b0n1 (Compute, NID 1037) - Not found in HSM Components.
    - x9000c3s4b0n1 (Compute, NID 1049) - Not found in HSM Components.
    - x9000c3s7b0n2 (Compute, NID 1062) - Not found in HSM Components.
    - x9000c1s0b1n0 (Compute, NID 1002) - Not found in HSM Components.
    - x9000c1s5b0n1 (Compute, NID 1021) - Not found in HSM Components.
    - x9000c1s5b0n2 (Compute, NID 1022) - Not found in HSM Components.
    - x9000c3s4b0n0 (Compute, NID 1048) - Not found in HSM Components.
    - x9000c1s3b1n0 (Compute, NID 1014) - Not found in HSM Components.
    - x9000c1s5b0n0 (Compute, NID 1020) - Not found in HSM Components.
    - x9000c3s7b0n1 (Compute, NID 1061) - Not found in HSM Components.
    - x9000c1s6b0n0 (Compute, NID 1024) - Not found in HSM Components.
    - x9000c3s0b0n1 (Compute, NID 1033) - Not found in HSM Components.
    - x9000c3s5b1n0 (Compute, NID 1054) - Not found in HSM Components.
    - x9000c1s6b0n2 (Compute, NID 1026) - Not found in HSM Components.
    - x9000c3s4b1n1 (Compute, NID 1051) - Not found in HSM Components.
    - x9000c3s7b0n3 (Compute, NID 1063) - Not found in HSM Components.
    - x9000c3s4b1n0 (Compute, NID 1050) - Not found in HSM Components.
    - x9000c3s6b0n2 (Compute, NID 1058) - Not found in HSM Components.
    - x9000c3s1b0n2 (Compute, NID 1038) - Not found in HSM Components.
    - x9000c3s1b0n3 (Compute, NID 1039) - Not found in HSM Components.
    - x9000c3s5b0n1 (Compute, NID 1053) - Not found in HSM Components.
    - x9000c1s3b0n1 (Compute, NID 1013) - Not found in HSM Components.
    - x9000c1s5b0n3 (Compute, NID 1023) - Not found in HSM Components.
    - x9000c3s6b0n0 (Compute, NID 1056) - Not found in HSM Components.
    - x9000c3s6b0n3 (Compute, NID 1059) - Not found in HSM Components.
    - x9000c3s7b0n0 (Compute, NID 1060) - Not found in HSM Components.
    - x9000c1s3b0n0 (Compute, NID 1012) - Not found in HSM Components.
    - x9000c3s5b0n0 (Compute, NID 1052) - Not found in HSM Components.
    - x9000c3s6b0n1 (Compute, NID 1057) - Not found in HSM Components.
    - x9000c1s3b1n1 (Compute, NID 1015) - Not found in HSM Components.
    - x9000c1s6b0n3 (Compute, NID 1027) - Not found in HSM Components.
    - x9000c3s3b0n1 (Compute, NID 1045) - Not found in HSM Components.
    - x9000c3s5b1n1 (Compute, NID 1055) - Not found in HSM Components.
  NodeBMCs: WARNING
    - x9000c1s6b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x9000c3s0b0 - Not found in HSM Components.
    - x9000c1s0b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x9000c3s1b0 - Not found in HSM Components.
    - x9000c3s4b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x9000c3s7b0 - Not found in HSM Components.
    - x9000c1s5b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x9000c1s3b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x9000c3s5b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x9000c3s4b1 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x9000c3s6b0 - Not found in HSM Components.
    - x9000c3s5b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
    - x9000c1s3b0 - Not found in HSM Components; Not found in HSM Redfish Endpoints.
  RouterBMCs: PASS
```
#### Mug - 2 River cabinets
Here is the new output:
```
ncn-m001:~/LOOK_HERE/rsjostrand # ./verify_hsm_discovery.py 
HSM Cabinet Summary
===================
x3000 (River)
  Discovered Nodes:          19 (14 Mgmt, 1 Application, 4 Compute)
  Discovered Node BMCs:      18
  Discovered Router BMCs:     1
  Discovered Chassis BMCs:    0
  Discovered Cab PDU Ctlrs:   0
  Discovered CMCs:            0
x3001 (River)
  Discovered Nodes:           5 (5 Mgmt, 0 Application, 0 Compute)
  Discovered Node BMCs:       5
  Discovered Router BMCs:     0
  Discovered Chassis BMCs:    0
  Discovered Cab PDU Ctlrs:   0
  Discovered CMCs:            0

River Cabinet Checks
============================
Checking cabinet x3000
x3000 (River)
  Nodes: PASS
  NodeBMCs: PASS
  RouterBMCs: PASS
  CMCs: PASS
  CabinetPDUControllers: PASS
Checking cabinet x3001
x3001 (River)
  Nodes: PASS
  NodeBMCs: PASS
  RouterBMCs: PASS
  CMCs: PASS
  CabinetPDUControllers: PASS

Mountain/Hill Cabinet Checks
============================
None Found.

EX2500 Cabinet Checks
============================
None Found.
```
Here is the output of the original script:
```
ncn-m001:~/LOOK_HERE/rsjostrand # /opt/cray/csm/scripts/hms_verification/verify_hsm_discovery.py 
HSM Cabinet Summary
===================
x3000 (River)
  Discovered Nodes:          19 (14 Mgmt, 1 Application, 4 Compute)
  Discovered Node BMCs:      18
  Discovered Router BMCs:     1
  Discovered Chassis BMCs:    0
  Discovered Cab PDU Ctlrs:   0
x3001 (River)
  Discovered Nodes:           5 (5 Mgmt, 0 Application, 0 Compute)
  Discovered Node BMCs:       5
  Discovered Router BMCs:     0
  Discovered Chassis BMCs:    0
  Discovered Cab PDU Ctlrs:   0

River Cabinet Checks
====================
x3000
  Nodes: PASS
  NodeBMCs: WARNING
    - x3000c0s1b0 - Not found in HSM Components; No mgmt port connection; BMC of mgmt node ncn-m001.
  RouterBMCs: PASS
  ChassisBMCs/CMCs: PASS
  CabinetPDUControllers: PASS
x3001
  Nodes: PASS
  NodeBMCs: PASS
  RouterBMCs: PASS
  ChassisBMCs/CMCs: PASS
  CabinetPDUControllers: PASS

Mountain/Hill Cabinet Checks
============================
None Found.
```
#### Shandy - 1 River cabinet with 4 Mountain cabinet
Here is the new output:

Here is the output of the original script:

#### Surtur - 1 River cabinet
Here is the new output:

Here is the output of the original script:


## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

