### PR TITLE
CASMHMS-5640 Move hardware-sensitive HMS CT tests into separate stage

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.4.6] - 2023-02-03
+### Changed
+- Moved hardware-sensitive CT tests into separate stage.
+
 ## [0.4.5]
 ### Changed
 - The verify_hsm_discovery.py script now properly supports EX2500 cabinets.

--- a/scripts/hms_verification/run_hardware_checks.sh
+++ b/scripts/hms_verification/run_hardware_checks.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+# MIT License
+# 
+# (C) Copyright [2023] Hewlett Packard Enterprise Development LP
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+# print_and_log <string>
+function print_and_log()
+{
+    if [[ -z "${LOG_PATH}" ]]; then
+        echo "ERROR: log path is not set"
+        exit 1
+    fi
+
+    MESSAGE="${1}"
+    if [[ -z "${MESSAGE}" ]]; then
+        echo "ERROR: no message to print and log"
+        exit 1
+    else
+        echo "${MESSAGE}" | tee -a ${LOG_PATH}
+    fi
+}
+
+# set up signal handling
+trap 'if [[ -f ${LOG_PATH} ]]; then \
+          echo Received kill signal, exiting with status code: 1 | tee -a ${LOG_PATH}; \
+      else \
+          echo Received kill signal, exiting with status code: 1; \
+      fi; \
+      exit 1' SIGHUP SIGINT SIGTERM
+
+DATE_TIME=$(date +"%Y%m%dT%H%M%S")
+LOG_PATH="/opt/cray/tests/hardware_checks-${DATE_TIME}.log"
+#TODO
+HELP_URL="https://github.com/Cray-HPE/docs-csm/blob/main/troubleshooting/hms_ct_manual_run.md"
+
+# sanity checks
+which helm &> /dev/null
+if [[ $? -ne 0 ]]; then
+    echo "ERROR: helm command missing"
+    exit 1
+fi
+
+touch ${LOG_PATH} &> /dev/null
+if [[ $? -ne 0 ]]; then
+    echo "ERROR: log file path is not writable: ${LOG_PATH}"
+    exit 1
+fi
+
+echo "Log file for run is: ${LOG_PATH}"
+
+echo "Running hardware checks..."
+helm test -n services cray-hms-smd --filter name=cray-hms-smd-check-hardware > ${LOG_PATH} 2>&1
+echo "DONE."
+
+if [[ -r "${LOG_PATH}" ]]; then
+    echo "" >> "${LOG_PATH}"
+    TEST_OUTPUT=$(cat "${LOG_PATH}")
+else
+    echo "ERROR: missing readable test output file: ${LOG_PATH}"
+    exit 1
+fi
+
+# parse hardware check output
+TEST_SUITE_HW_CHECK_OUTPUT=$(echo "${TEST_OUTPUT}" | sed -n '/TEST SUITE:.*cray-hms-smd-check-hardware/,/Phase:/p')
+if [[ -z "${TEST_SUITE_HW_CHECK_OUTPUT}" ]]; then
+    print_and_log "ERROR: cray-hms-smd-check-hardware checks didn't appear to run"
+else
+    TEST_SUITE_HW_CHECK_PARSE_CHECK=$(echo "${TEST_SUITE_HW_CHECK_OUTPUT}" | grep -E "TEST SUITE:" | wc -l | tr -d " ")
+    if [[ ${TEST_SUITE_HW_CHECK_PARSE_CHECK} -ne 1 ]]; then
+        print_and_log "ERROR: failed to parse Helm output for cray-hms-smd-check-hardware data"
+        # ensure invalid data is not processed
+        TEST_SUITE_HW_CHECK_OUTPUT=""
+    fi
+fi
+TEST_SUITE_HW_CHECK_PASS_CHECK=$(echo "${TEST_SUITE_HW_CHECK_OUTPUT}" | grep -E "Phase:.*Succeeded" | wc -l | tr -d " ")
+
+# print results
+if [[ ${TEST_SUITE_HW_CHECK_PASS_CHECK} -eq 1 ]]; then
+    print_and_log "SUCCESS: Hardware checks passed"
+    exit 0
+else
+    print_and_log "FAILURE: Hardware checks FAILED"
+    #TODO
+    echo "For troubleshooting and manual steps, see: ${HELP_URL}"
+    exit 1
+fi

--- a/scripts/hms_verification/run_hardware_checks.sh
+++ b/scripts/hms_verification/run_hardware_checks.sh
@@ -49,8 +49,6 @@ trap 'if [[ -f ${LOG_PATH} ]]; then \
 
 DATE_TIME=$(date +"%Y%m%dT%H%M%S")
 LOG_PATH="/opt/cray/tests/hardware_checks-${DATE_TIME}.log"
-#TODO
-HELP_URL="https://github.com/Cray-HPE/docs-csm/blob/main/troubleshooting/hms_ct_manual_run.md"
 
 # sanity checks
 which helm &> /dev/null
@@ -99,7 +97,5 @@ if [[ ${TEST_SUITE_HW_CHECK_PASS_CHECK} -eq 1 ]]; then
     exit 0
 else
     print_and_log "FAILURE: Hardware checks FAILED"
-    #TODO
-    echo "For troubleshooting and manual steps, see: ${HELP_URL}"
     exit 1
 fi

--- a/scripts/hms_verification/run_hms_ct_tests.sh
+++ b/scripts/hms_verification/run_hms_ct_tests.sh
@@ -205,7 +205,7 @@ if [[ ${TEST_SERVICE} == "all" ]]; then
 
         # parse smoke test output
         if [[ ${TEST_SMOKE} -eq 1 ]]; then
-            TEST_SUITE_SMOKE_OUTPUT=$(echo "${ALL_OUTPUT}" | sed -n '/TEST SUITE:.*'${TEST_DEPLOYMENT}'-test-smoke/,/^Phase:/p')
+            TEST_SUITE_SMOKE_OUTPUT=$(echo "${ALL_OUTPUT}" | sed -n '/TEST SUITE:.*'${TEST_DEPLOYMENT}'-test-smoke/,/Phase:/p')
             if [[ -z "${TEST_SUITE_SMOKE_OUTPUT}" ]]; then
                 print_and_log "ERROR: ${TEST_DEPLOYMENT}-test-smoke tests didn't appear to run"
             else
@@ -224,7 +224,7 @@ if [[ ${TEST_SERVICE} == "all" ]]; then
 
         # parse functional test output
         if [[ ${TEST_FUNCTIONAL} -eq 1 ]]; then
-            TEST_SUITE_FUNCTIONAL_OUTPUT=$(echo "${ALL_OUTPUT}" | sed -n '/TEST SUITE:.*'${TEST_DEPLOYMENT}'-test-functional/,/^Phase:/p')
+            TEST_SUITE_FUNCTIONAL_OUTPUT=$(echo "${ALL_OUTPUT}" | sed -n '/TEST SUITE:.*'${TEST_DEPLOYMENT}'-test-functional/,/Phase:/p')
             if [[ -z "${TEST_SUITE_FUNCTIONAL_OUTPUT}" ]]; then
                 print_and_log "ERROR: ${TEST_DEPLOYMENT}-test-functional tests didn't appear to run"
             else
@@ -355,7 +355,7 @@ else
 
     # parse smoke test output
     if [[ ${TEST_SMOKE} -eq 1 ]]; then
-        TEST_SUITE_SMOKE_OUTPUT=$(echo "${TEST_OUTPUT}" | sed -n '/TEST SUITE:.*'${TEST_DEPLOYMENT}'-test-smoke/,/^Phase:/p')
+        TEST_SUITE_SMOKE_OUTPUT=$(echo "${TEST_OUTPUT}" | sed -n '/TEST SUITE:.*'${TEST_DEPLOYMENT}'-test-smoke/,/Phase:/p')
         if [[ -z "${TEST_SUITE_SMOKE_OUTPUT}" ]]; then
             print_and_log "ERROR: ${TEST_DEPLOYMENT}-test-smoke tests didn't appear to run"
         else
@@ -374,7 +374,7 @@ else
 
     # parse functional test output
     if [[ ${TEST_FUNCTIONAL} -eq 1 ]]; then
-        TEST_SUITE_FUNCTIONAL_OUTPUT=$(echo "${TEST_OUTPUT}" | sed -n '/TEST SUITE:.*'${TEST_DEPLOYMENT}'-test-functional/,/^Phase:/p')
+        TEST_SUITE_FUNCTIONAL_OUTPUT=$(echo "${TEST_OUTPUT}" | sed -n '/TEST SUITE:.*'${TEST_DEPLOYMENT}'-test-functional/,/Phase:/p')
         if [[ -z "${TEST_SUITE_FUNCTIONAL_OUTPUT}" ]]; then
             print_and_log "ERROR: ${TEST_DEPLOYMENT}-test-functional tests didn't appear to run"
         else


### PR DESCRIPTION
### Summary and Scope

This change moves the HMS CT tests that run in the CSM validation steps and often fail due to hardware issues into a new hardware-checks test stage that is separate from the rest of the HMS tests. These tests are optional and do not block CSM installs or upgrades.

### Issues and Related PRs

* Resolves CASMHMS-5640

### Testing

This change was tested in the build pipeline, as well as on Surtur by deploying the updated tests and wrapper scripts, executing various sets of tests and hardware checks, and verifying that they all passed. Testing was also completed to verify that both test and hardware-check failures were handled properly.

### Risks and Mitigations

Low risk, impacts HMS CT testing only.