### PR TITLE
CASMINST-5969: Linting of minor language and formatting errors

### DIFF
--- a/scripts/admin_access/set_ssh_keys.py
+++ b/scripts/admin_access/set_ssh_keys.py
@@ -2,7 +2,7 @@
 
 # MIT License
 #
-# (C) Copyright [2021] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2021, 2023] Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -33,7 +33,7 @@ dryrun = False
 debugLevel = 0
 
 
-# Create a k8s client object for use in getting auth tokena.
+# Create a k8s client object for use in getting auth tokens.
 
 def getK8sClient():
 	config.load_kube_config()
@@ -347,6 +347,3 @@ def main():
 if __name__ == "__main__":
 	ret = main()
 	exit(ret)
-
-
-

--- a/scripts/hms_verification/README_Arubafix.md
+++ b/scripts/hms_verification/README_Arubafix.md
@@ -8,7 +8,7 @@ Hence the need for an automated way to check if this issue is affecting
 the system and if so to fix it.
 
 Note that this script is not 100% automated -- it does require user input.
-That input is the switch management software's admin password.   Without this
+That input is the switch management software's admin password.  Without this
 the commands to fix the SNMP issue cannot be executed on the switch(es).
 Since passwords cannot be coded in any way into any application source code,
 this is the only way to handle this situation.

--- a/scripts/hms_verification/arubafix.sh
+++ b/scripts/hms_verification/arubafix.sh
@@ -3,7 +3,7 @@
 
 # MIT License
 # 
-# (C) Copyright [2021] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2021, 2023] Hewlett Packard Enterprise Development LP
 # 
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -27,7 +27,7 @@
 # The bug: SNMP doesn't always report all MAC addr entries, so HMS discovery
 # job reports it as not found.  So no idea which leaf switch should have it.
 # Thus: the SNMP reset has to be applied to all leaf switches, to be sure.
-# One way to figger out the switch that needs the fix -- use the mgmt interface
+# One way to figure out the switch that needs the fix -- use the mgmt interface
 # to look for the MAC, using e.g. 'ssh sw-leaf-001 show mac-address-table'.
 # If MAC is found in that table, that is the one that needs to be reset.
 # This may be a future enhancement.
@@ -41,13 +41,13 @@ debugLevel=0
 testMode=0
 
 resetSNMP() {
-	swname=$1
+    swname=$1
 
-	echo "Performing SNMP Reset on Aruba leaf switch: ${swname}"
-	echo " "
-	expLog=/tmp/swreset_exp_${swname}.out
+    echo "Performing SNMP Reset on Aruba leaf switch: ${swname}"
+    echo " "
+    expLog=/tmp/swreset_exp_${swname}.out
 
- 	expect -c "
+    expect -c "
 spawn ssh admin@${swname}
 expect \"password: \"
 send \"${SWPW}\n\"
@@ -65,54 +65,54 @@ expect \"# \"
 send \"exit\n\"
 " > $expLog 2>&1
 
-	if [ $? -ne 0 ]; then
-		echo "Communication with $swname failed."
-		echo " "
-		echo "Communication log:"
-		echo " "
-		cat $expLog
-		echo " "
-		return 1
-	else
-		echo "Aruba switch $swname SNMP reset succeeded."
-	fi
+    if [ $? -ne 0 ]; then
+        echo "Communication with $swname failed."
+        echo " "
+        echo "Communication log:"
+        echo " "
+        cat $expLog
+        echo " "
+        return 1
+    else
+        echo "Aruba switch $swname SNMP reset succeeded."
+    fi
 
-	if (( debugLevel > 0 )); then
-		cat $expLog
-	fi
+    if (( debugLevel > 0 )); then
+        cat $expLog
+    fi
 
-	return 0
+    return 0
 }
 
 usage() {
-	echo "Usage: `basename $0` [-h] [-d] [-t]"
-	echo " "
-	echo "   -h    Help text"
-	echo "   -d    Print debug info during execution."
-	echo "   -t    Test mode, don't touch Aruba switches."
-	echo " "
+    echo "Usage: `basename $0` [-h] [-d] [-t]"
+    echo " "
+    echo "   -h    Help text"
+    echo "   -d    Print debug info during execution."
+    echo "   -t    Test mode, don't touch Aruba switches."
+    echo " "
 }
 
 
 ### ENTRY POINT
 
 while getopts "hdt" opt; do
-	case "${opt}" in
-		h)
-			usage
-			exit 0
-			;;
-		d)
-			(( debugLevel = debugLevel + 1 ))
-			;;
-		t)
-			testMode=1
-			;;
-		*)
-			usage
-			exit 0
-			;;
-	esac
+    case "${opt}" in
+        h)
+            usage
+            exit 0
+            ;;
+        d)
+            (( debugLevel = debugLevel + 1 ))
+            ;;
+        t)
+            testMode=1
+            ;;
+        *)
+            usage
+            exit 0
+            ;;
+    esac
 done
 
 ## Get a list of Aruba leaf switches.  If there are none, nothing to do.
@@ -124,14 +124,14 @@ swJSON="/tmp/sw.JSON"
 cray sls search hardware list --type comptype_mgmt_switch --format json > $swJSON
 
 if [ $? -ne 0 ]; then
-	echo " "
-	echo "ERROR executing SLS switch HW search:"
-	cat $swJSON
-	echo " "
-	echo "For troubleshooting and manual steps, see ${HELP_URL}."
-	echo " "
-	echo "Exiting..."
-	exit 1
+    echo " "
+    echo "ERROR executing SLS switch HW search:"
+    cat $swJSON
+    echo " "
+    echo "For troubleshooting and manual steps, see ${HELP_URL}."
+    echo " "
+    echo "Exiting..."
+    exit 1
 fi
 
 echo " "
@@ -140,15 +140,15 @@ echo "==> Fetching switch hostnames..."
 swNames=$(cat $swJSON | jq '.[] | select((.Class == "River") and (.ExtraProperties.Brand == "Aruba"))' | jq '.ExtraProperties.Aliases[0]' | sed 's/"//g')
 
 if (( debugLevel > 0 )); then
-	echo "Switches found:"
-	echo $swNames
-	echo " "
+    echo "Switches found:"
+    echo $swNames
+    echo " "
 fi
 
 if [[ "${swNames}" == "" ]]; then
-	echo " "
-	echo "No Aruba switches found, nothing to do, exiting."
-	exit 0
+    echo " "
+    echo "No Aruba switches found, nothing to do, exiting."
+    exit 0
 fi
 
 
@@ -160,29 +160,29 @@ fi
 #    until it is.
 
 for (( iter = 1; iter <= 30; iter = iter + 1 )); do
-	if (( iter == 1 )); then
-		echo "==> Looking for completed HMS discovery pod..."
-	else
-		echo "==> Looking for completed HMS discovery pod, attempt #${iter}..."
-	fi
+    if (( iter == 1 )); then
+        echo "==> Looking for completed HMS discovery pod..."
+    else
+        echo "==> Looking for completed HMS discovery pod, attempt #${iter}..."
+    fi
 
-	HMS_DISCOVERY_POD=$(kubectl -n services get pods -l app=hms-discovery | tail -n 1 | grep Completed | awk '{ print $1 }')
-	if [[ "${HMS_DISCOVERY_POD}" != "" ]]; then
-		break
-	fi
-	sleep 5
+    HMS_DISCOVERY_POD=$(kubectl -n services get pods -l app=hms-discovery | tail -n 1 | grep Completed | awk '{ print $1 }')
+    if [[ "${HMS_DISCOVERY_POD}" != "" ]]; then
+        break
+    fi
+    sleep 5
 done
 
 if [[ "${HMS_DISCOVERY_POD}" == "" ]]; then
-	echo "ERROR: No valid HMS discovery pod found; discovery in progress? Exiting."
-	echo " "
-	echo "For troubleshooting and manual steps, see ${HELP_URL}."
-	echo " "
-	exit 1
+    echo "ERROR: No valid HMS discovery pod found; discovery in progress? Exiting."
+    echo " "
+    echo "For troubleshooting and manual steps, see ${HELP_URL}."
+    echo " "
+    exit 1
 fi
 
 if (( debugLevel > 0 )); then
-	echo "Most recent HMS discover pod: $HMS_DISCOVERY_POD"
+    echo "Most recent HMS discover pod: $HMS_DISCOVERY_POD"
 fi
 
 kubectl -n services logs $HMS_DISCOVERY_POD -c hms-discovery > $DISCOVERY_LOG 2>&1
@@ -196,16 +196,16 @@ echo " "
 UNKNOWN_MACS=$(cat $DISCOVERY_LOG | jq 'select(.msg == "MAC address in HSM not found in any switch!").unknownComponent.ID' -r -c)
 
 if (( debugLevel > 0 )); then
-	echo "Unknown MACs:"
-	echo "$UNKNOWN_MACS"
+    echo "Unknown MACs:"
+    echo "$UNKNOWN_MACS"
 fi
 
 if [[ "${UNKNOWN_MACS}" == "" ]]; then
-	echo "No unknown/undiscovered MACs found;"
-	echo "no Aruba issue on this system, exiting."
-	exit 0
+    echo "No unknown/undiscovered MACs found;"
+    echo "no Aruba issue on this system, exiting."
+    exit 0
 else
-	echo "Found unknown/undiscovered MACs in discovery log."
+    echo "Found unknown/undiscovered MACs in discovery log."
 fi
 
 # 3. Use the logs to get MAC addrs of ones found on the switches (but not 
@@ -216,8 +216,8 @@ echo "==> Looking for unknown/undiscovered MAC addrs in discovery log..."
 FOUND_IN_SWITCH_MACS=$(cat $DISCOVERY_LOG | jq 'select(.msg == "Found MAC address in switch.").macWithoutPunctuation' -r)
 
 if (( debugLevel > 0 )); then
-	echo "MACS in switches:"
-	echo "$FOUND_IN_SWITCH_MACS"
+    echo "MACS in switches:"
+    echo "$FOUND_IN_SWITCH_MACS"
 fi
 
 # 4. Do a diff to match the 2 sets.  Any MACs not found in both indicate
@@ -227,7 +227,7 @@ echo " "
 echo "==> Identifying undiscovered MAC mismatches..."
 echo " "
 if (( debugLevel > 1 )); then
-	diff -y <(echo "$UNKNOWN_MACS" | sort -u) <(echo "$FOUND_IN_SWITCH_MACS" \
+    diff -y <(echo "$UNKNOWN_MACS" | sort -u) <(echo "$FOUND_IN_SWITCH_MACS" \
         | sort -u)
 fi
 
@@ -237,42 +237,42 @@ hasbadmac=$?
 rslt=0
 
 if [ $hasbadmac -ne 0 ]; then
-	# We need another check if there are mismatches.  It's possible some of them
-	# are from another network that we don't care  about.
+    # We need another check if there are mismatches.  It's possible some of them
+    # are from another network that we don't care about.
 
-	suspectMACs=$(diff -y <(echo "$UNKNOWN_MACS" | sort -u) <(echo "$FOUND_IN_SWITCH_MACS" \
+    suspectMACs=$(diff -y <(echo "$UNKNOWN_MACS" | sort -u) <(echo "$FOUND_IN_SWITCH_MACS" \
         | sort -u) | grep -e '<' -e '|' | awk '{printf("%s\n",$1)}')
 
 
-	for mac in ${suspectMACs}; do
-		if (( debugLevel > 1 )); then
-			echo "Unknown MAC: .${mac}."
-		fi
+    for mac in ${suspectMACs}; do
+        if (( debugLevel > 1 )); then
+            echo "Unknown MAC: .${mac}."
+        fi
 
-		# Get IP
-		ip=$(cat $DISCOVERY_LOG | jq "select(.unknownComponent.ID == \"${mac}\") | .unknownComponent.IPAddress" | sed 's/"//g')
+        # Get IP
+        ip=$(cat $DISCOVERY_LOG | jq "select(.unknownComponent.ID == \"${mac}\") | .unknownComponent.IPAddress" | sed 's/"//g')
 
-		NW=$(cray sls search networks list --ip-address $ip --format json | jq .[].Name | sed 's/"//g')
+        NW=$(cray sls search networks list --ip-address $ip --format json | jq .[].Name | sed 's/"//g')
 
-		if (( debugLevel > 1 )); then
-			echo "Unknown MAC's IP: ${ip}, network: ${NW}."
-		fi
+        if (( debugLevel > 1 )); then
+            echo "Unknown MAC's IP: ${ip}, network: ${NW}."
+        fi
 
-		#Ignore networks that are not one of "HMN", "HMN_RVR", or "HMN_MTN"
-		if [ "${NW}" == "HMN" -o "${NW}" == "HMN_RVR" -o "${NW}" == "HMN_MTN" ]; then
-			rslt=1
-			break
-		else
-			echo "INFO: Unknown MAC: ${mac} is on non-relevant network: ${NW}, ignoring."
-		fi
-	done
+        #Ignore networks that are not one of "HMN", "HMN_RVR", or "HMN_MTN"
+        if [ "${NW}" == "HMN" -o "${NW}" == "HMN_RVR" -o "${NW}" == "HMN_MTN" ]; then
+            rslt=1
+            break
+        else
+            echo "INFO: Unknown MAC: ${mac} is on non-relevant network: ${NW}, ignoring."
+        fi
+    done
 fi
 
 if [[ $rslt == 0 ]]; then
-	echo "============================"
-	echo "= No Aruba MAC mismatches. ="
-	echo "============================"
-	exit 0
+    echo "============================"
+    echo "= No Aruba MAC mismatches. ="
+    echo "============================"
+    exit 0
 fi
 
 ## If we got here, we have a discovery problem.  We need to delete the SNMP
@@ -293,9 +293,9 @@ echo "= Performing switch SNMP resets.           ="
 echo "============================================"
 
 if (( testMode != 0 )); then
-	echo " "
-	echo "[Test mode, not acting on Aruba switches.]"
-	exit 0
+    echo " "
+    echo "[Test mode, not acting on Aruba switches.]"
+    exit 0
 fi
 
 
@@ -312,22 +312,21 @@ echo " "
 
 ok=1
 for mswitch in ${swNames}; do
-	resetSNMP $mswitch
-	if [ $? -ne 0 ]; then
-		ok=0
-	fi
-	
+    resetSNMP $mswitch
+    if [ $? -ne 0 ]; then
+        ok=0
+    fi
+    
 done
 
 if (( ok != 1 )); then
-	echo " "
-	echo "Some Aruba switches did not get SNMP reset, Exiting..."
-	echo " "
-	echo "For troubleshooting and manual steps, see ${HELP_URL}."
-	echo " "
-	exit 1
+    echo " "
+    echo "Some Aruba switches did not get SNMP reset, Exiting..."
+    echo " "
+    echo "For troubleshooting and manual steps, see ${HELP_URL}."
+    echo " "
+    exit 1
 fi
 
 echo " "
 exit 0
-

--- a/scripts/hms_verification/verify_hsm_discovery.py
+++ b/scripts/hms_verification/verify_hsm_discovery.py
@@ -2,7 +2,7 @@
 
 # MIT License
 #
-# (C) Copyright [2021-2022] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2021-2023] Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -21,7 +21,6 @@
 # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
-
 
 
 import json
@@ -65,111 +64,110 @@ from kubernetes import client, config
 # Data structure to contain cabinet info.
 
 class CabInfo():
-	def __init__(self, xn, xc):
-		self.xname = xn
-		self.xclass = xc
+    def __init__(self, xn, xc):
+        self.xname = xn
+        self.xclass = xc
 
-# Create a k8s client object for use in getting auth tokena.
+# Create a k8s client object for use in getting auth tokens.
 
 def getK8sClient():
-	config.load_kube_config()
-	k8sClient = client.CoreV1Api()
-	return k8sClient
+    config.load_kube_config()
+    k8sClient = client.CoreV1Api()
+    return k8sClient
 
 # Fetch auth token for HMS REST API calls.
 
 def getAuthenticationToken():
-	URL = "https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token"
+    URL = "https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token"
 
-	kSecret = getK8sClient().read_namespaced_secret("admin-client-auth", "default")
-	secret = b64decode(kSecret.data['client-secret']).decode("utf-8")
+    kSecret = getK8sClient().read_namespaced_secret("admin-client-auth", "default")
+    secret = b64decode(kSecret.data['client-secret']).decode("utf-8")
 
-	DATA = {
-		"grant_type": "client_credentials",
-		"client_id": "admin-client",
-		"client_secret": secret
-	}
+    DATA = {
+        "grant_type": "client_credentials",
+        "client_id": "admin-client",
+        "client_secret": secret
+    }
 
-	try:
-		r = requests.post(url=URL, data=DATA)
-	except OSError:
-		return ""
+    try:
+        r = requests.post(url=URL, data=DATA)
+    except OSError:
+        return ""
 
-	result = json.loads(r.text)
-	return result['access_token']
+    result = json.loads(r.text)
+    return result['access_token']
 
 # Func to get a JSON payload from a URL.  It's assumed to be a full URL.
 # Also note that we'll only ever be contacting HMS services.
 
 def doRest(uri, authToken):
-	getHeaders = {'Authorization': 'Bearer %s' % authToken,}
-	r = requests.get(url=uri, headers=getHeaders)
-	retJSON = r.text
+    getHeaders = {'Authorization': 'Bearer %s' % authToken,}
+    r = requests.get(url=uri, headers=getHeaders)
+    retJSON = r.text
 
-	if r.status_code >= 300:
-		ret = 1
-	else:
-		ret = 0
+    if r.status_code >= 300:
+        ret = 1
+    else:
+        ret = 0
 
-	return retJSON, ret
+    return retJSON, ret
 
 
 # Get HSM component data
 
 def getHSMComponents(authToken):
-	url = "https://api-gw-service-nmn.local/apis/smd/hsm/v1/State/Components"
-	compsJSON, rstat = doRest(url, authToken)
-	return compsJSON, rstat
-
+    url = "https://api-gw-service-nmn.local/apis/smd/hsm/v1/State/Components"
+    compsJSON, rstat = doRest(url, authToken)
+    return compsJSON, rstat
 
 
 # Get HSM RFEP data
 
 def getHSMRFEP(authToken):
-	url = "https://api-gw-service-nmn.local/apis/smd/hsm/v1/Inventory/RedfishEndpoints"
-	rfepJSON, rstat = doRest(url, authToken)
-	return rfepJSON, rstat
+    url = "https://api-gw-service-nmn.local/apis/smd/hsm/v1/Inventory/RedfishEndpoints"
+    rfepJSON, rstat = doRest(url, authToken)
+    return rfepJSON, rstat
 
 
 # Get SLS HW data
 
 def getSLSHWData(authToken):
-	url = "https://api-gw-service-nmn.local/apis/sls/v1/hardware"
-	slsJSON, rstat = doRest(url, authToken)
-	return slsJSON, rstat
+    url = "https://api-gw-service-nmn.local/apis/sls/v1/hardware"
+    slsJSON, rstat = doRest(url, authToken)
+    return slsJSON, rstat
 
 
 # Returns a list of cabinets and their type (RV,MT,HILL).
 # This is taken from the SLS data.
 
 def getCabList(slsJSON):
-	cabList = []
+    cabList = []
 
-	j = json.loads(slsJSON)
+    j = json.loads(slsJSON)
 
-	for comp in j:
-		if comp['TypeString'] == "Cabinet":
-			cabList.append(CabInfo(comp['Xname'], comp['Class']))
+    for comp in j:
+        if comp['TypeString'] == "Cabinet":
+            cabList.append(CabInfo(comp['Xname'], comp['Class']))
 
-	return cabList
+    return cabList
 
 
 # Given a BMC, return a list of connected mgmt port NICs.
 
 def findNodeNics(bmc, slsJSON):
-	nics = []
-	for comp in slsJSON:
-		if not "ExtraProperties" in comp:
-			continue
+    nics = []
+    for comp in slsJSON:
+        if not "ExtraProperties" in comp:
+            continue
 
-		if not "NodeNics" in comp['ExtraProperties']:
-			continue
+        if not "NodeNics" in comp['ExtraProperties']:
+            continue
 
-		for nic in comp['ExtraProperties']['NodeNics']:
-			if nic == bmc:
-				nics.append(comp['Xname'])
+        for nic in comp['ExtraProperties']['NodeNics']:
+            if nic == bmc:
+                nics.append(comp['Xname'])
 
-	return nics
+    return nics
 
 
 # Convenience function, checks SLS components to see if they are present in
@@ -177,37 +175,37 @@ def findNodeNics(bmc, slsJSON):
 # associated with it in SLS.  Returns a message with relevant info.
 
 def doChecks(xclass, comp, bname, ctype, compJSON, rfepJSON, slsJSON):
-	noc = ""
+    noc = ""
 
-	# Check state components presence
-	flds = compJSON['Components']
-	filtered = list(filter(lambda f: (f['ID'] == bname), flds))
-	if not filtered:
-		noc = "Not found in HSM Components"
+    # Check state components presence
+    flds = compJSON['Components']
+    filtered = list(filter(lambda f: (f['ID'] == bname), flds))
+    if not filtered:
+        noc = "Not found in HSM Components"
 
-	# Check RF Endpoints presence
-	flds = rfepJSON['RedfishEndpoints']
-	filtered = list(filter(lambda f: (f['ID'] == bname), flds))
-	if not filtered:
-		if len(noc) > 0:
-			noc += "; "
-		noc += "Not found in HSM Redfish Endpoints"
+    # Check RF Endpoints presence
+    flds = rfepJSON['RedfishEndpoints']
+    filtered = list(filter(lambda f: (f['ID'] == bname), flds))
+    if not filtered:
+        if len(noc) > 0:
+            noc += "; "
+        noc += "Not found in HSM Redfish Endpoints"
 
-	if xclass == "River":
-		# Check mgmt port connection
-		filtered = findNodeNics(bname, slsJSON)
-		if not filtered:
-			if len(noc) > 0:
-				noc += "; "
-			noc += "No mgmt port connection"
-			if ctype == "NodeBMC":
-				# Check if this is a mgmt NCN, if so, print alias.  This is
-				# determined by looking at the Role -- look for Management.
-				# Then, grab the ExtraProperties/Aliases.
-				if comp['ExtraProperties']['Role'] == "Management":
-					noc += "; BMC of mgmt node " + comp['ExtraProperties']['Aliases'][0]
+    if xclass == "River":
+        # Check mgmt port connection
+        filtered = findNodeNics(bname, slsJSON)
+        if not filtered:
+            if len(noc) > 0:
+                noc += "; "
+            noc += "No mgmt port connection"
+            if ctype == "NodeBMC":
+                # Check if this is a mgmt NCN, if so, print alias.  This is
+                # determined by looking at the Role -- look for Management.
+                # Then, grab the ExtraProperties/Aliases.
+                if comp['ExtraProperties']['Role'] == "Management":
+                    noc += "; BMC of mgmt node " + comp['ExtraProperties']['Aliases'][0]
 
-	return noc
+    return noc
 
 
 # Generate a per-cabinet summary containing numbers of nodes, BMCs, etc.
@@ -215,434 +213,434 @@ def doChecks(xclass, comp, bname, ctype, compJSON, rfepJSON, slsJSON):
 # the RF endpoints instead?
 
 def genSummary(slsData, compData):
-	cabList = getCabList(slsData)
-	# Sort by cab num
-	clSorted = sorted(cabList, key=lambda cab: cab.xname)
+    cabList = getCabList(slsData)
+    # Sort by cab num
+    clSorted = sorted(cabList, key=lambda cab: cab.xname)
 
-	print("HSM Cabinet Summary")
-	print("===================")
+    print("HSM Cabinet Summary")
+    print("===================")
 
-	cdata = json.loads(compData)
+    cdata = json.loads(compData)
 
-	for cab in clSorted:
-		nodes = 0
-		nodebmcs = 0
-		rtrbmcs = 0
-		chassisbmcs = 0
-		cabpducontrollers = 0
-		appNodes = 0
-		mgmtNodes = 0
-		compNodes = 0
+    for cab in clSorted:
+        nodes = 0
+        nodebmcs = 0
+        rtrbmcs = 0
+        chassisbmcs = 0
+        cabpducontrollers = 0
+        appNodes = 0
+        mgmtNodes = 0
+        compNodes = 0
 
-		for comp in cdata['Components']:
-			if not comp['ID'].startswith(cab.xname):
-				continue
+        for comp in cdata['Components']:
+            if not comp['ID'].startswith(cab.xname):
+                continue
 
-			ctype = comp['Type']
-			if ctype == "Node":
-				nodes += 1
-				if comp['Role'] == "Compute":
-					compNodes += 1
-				elif comp['Role'] == "Management":
-					mgmtNodes += 1
-				elif comp['Role'] == "Application":
-					appNodes += 1
-			elif ctype == "NodeBMC":
-				nodebmcs += 1
-			elif ctype == "RouterBMC":
-				rtrbmcs += 1
-			elif ctype == "ChassisBMC":
-				chassisbmcs += 1
-			elif ctype == "CabinetPDUController":
-				cabpducontrollers += 1
+            ctype = comp['Type']
+            if ctype == "Node":
+                nodes += 1
+                if comp['Role'] == "Compute":
+                    compNodes += 1
+                elif comp['Role'] == "Management":
+                    mgmtNodes += 1
+                elif comp['Role'] == "Application":
+                    appNodes += 1
+            elif ctype == "NodeBMC":
+                nodebmcs += 1
+            elif ctype == "RouterBMC":
+                rtrbmcs += 1
+            elif ctype == "ChassisBMC":
+                chassisbmcs += 1
+            elif ctype == "CabinetPDUController":
+                cabpducontrollers += 1
 
-		print("%s (%s)" % (cab.xname, cab.xclass))
-		if cab.xclass == "River":
-			print("  Discovered Nodes:         %3d (%d Mgmt, %d Application, %d Compute)" %
-				(nodes, mgmtNodes, appNodes, compNodes))
-		else:
-			print("  Discovered Nodes:         %3d" % (nodes))
+        print("%s (%s)" % (cab.xname, cab.xclass))
+        if cab.xclass == "River":
+            print("  Discovered Nodes:         %3d (%d Mgmt, %d Application, %d Compute)" %
+                (nodes, mgmtNodes, appNodes, compNodes))
+        else:
+            print("  Discovered Nodes:         %3d" % (nodes))
 
-		print("  Discovered Node BMCs:     %3d" % (nodebmcs))
-		print("  Discovered Router BMCs:   %3d" % (rtrbmcs))
-		print("  Discovered Chassis BMCs:  %3d" % (chassisbmcs))
-		if cab.xclass == "River":
-			print("  Discovered Cab PDU Ctlrs: %3d" % (cabpducontrollers))
+        print("  Discovered Node BMCs:     %3d" % (nodebmcs))
+        print("  Discovered Router BMCs:   %3d" % (rtrbmcs))
+        print("  Discovered Chassis BMCs:  %3d" % (chassisbmcs))
+        if cab.xclass == "River":
+            print("  Discovered Cab PDU Ctlrs: %3d" % (cabpducontrollers))
 
-	print("")
+    print("")
 
 
 # Generate River cabinet detailed report.
 
 def genRiverDetails(slsData, compData, rfepData):
-	numErrs = 0
+    numErrs = 0
 
-	slsJSON = json.loads(slsData)
-	compJSON = json.loads(compData)
-	rfepJSON = json.loads(rfepData)
+    slsJSON = json.loads(slsData)
+    compJSON = json.loads(compData)
+    rfepJSON = json.loads(rfepData)
 
-	cabList = getCabList(slsData)
-	# Sort by cab num
-	clSorted = sorted(cabList, key=lambda cab: cab.xname)
+    cabList = getCabList(slsData)
+    # Sort by cab num
+    clSorted = sorted(cabList, key=lambda cab: cab.xname)
 
-	print("River Cabinet Checks")
-	print("====================")
+    print("River Cabinet Checks")
+    print("====================")
 
-	for cab in clSorted:
-		errs = []
+    for cab in clSorted:
+        errs = []
 
-		# For each cab, filter for river class, ignore mountain/hill.
-		if cab.xclass != "River":
-			continue
+        # For each cab, filter for river class, ignore mountain/hill.
+        if cab.xclass != "River":
+            continue
 
-		print("%s" % (cab.xname))
+        print("%s" % (cab.xname))
 
-		# Iterate all nodes in SLS.  Check for not present in comps/rfeps,
-		# mgmt ports.  Any missing/mismatch is a FAIL.
+        # Iterate all nodes in SLS.  Check for not present in comps/rfeps,
+        # mgmt ports.  Any missing/mismatch is a FAIL.
 
-		nodes = list(filter(lambda f: (f['TypeString'] == "Node"), slsJSON))
-		for comp in nodes:
-			if not comp['Xname'].startswith(cab.xname):
-				continue
+        nodes = list(filter(lambda f: (f['TypeString'] == "Node"), slsJSON))
+        for comp in nodes:
+            if not comp['Xname'].startswith(cab.xname):
+                continue
 
-			flds = compJSON['Components']
-			filtered = list(filter(lambda f: (f['ID'] == comp['Xname']), flds))
-			if not filtered:
-				# Not all river nodes have NIDs, so check for that.
-				nidStr = "N/A"
-				if "NID" in comp['ExtraProperties']:
-					nidStr = "%d" % (comp['ExtraProperties']['NID'])
+            flds = compJSON['Components']
+            filtered = list(filter(lambda f: (f['ID'] == comp['Xname']), flds))
+            if not filtered:
+                # Not all river nodes have NIDs, so check for that.
+                nidStr = "N/A"
+                if "NID" in comp['ExtraProperties']:
+                    nidStr = "%d" % (comp['ExtraProperties']['NID'])
 
-				errs.append("- %s (%s, NID %s) - Not found in HSM Components." %
-					(comp['Xname'], comp['ExtraProperties']['Role'], nidStr))
+                errs.append("- %s (%s, NID %s) - Not found in HSM Components." %
+                    (comp['Xname'], comp['ExtraProperties']['Role'], nidStr))
 
-		# Print out the node info.
-		if not errs:
-			print("  Nodes: PASS")
-		else:
-			numErrs += 1
-			print("  Nodes: FAIL")
-			for emsg in errs:
-				print("    %s" % (emsg))
-
-
-		# Iterate NodeBMCs in SLS.  This is tricky, the SLS data doesn't have
-		# node BMCs, need to infer them from the nodes using the Parent field.
-		# Check for presence in comps/RFEPs and mgmt ports, mismatches == FAIL.
-		# If no mgmt port, check if it's a mgmt NCN and if so, report it as
-		# info.
-
-		errs = []
-		warns = []
-		mappedComps = {}
-
-		for comp in nodes:
-			if not comp['Xname'].startswith(cab.xname):
-				continue
-
-			bname = comp['Parent']
-			if bname in mappedComps:
-				continue
-
-			mappedComps[bname] = True
-			noc = doChecks(cab.xclass, comp, bname, "NodeBMC", compJSON, rfepJSON, slsJSON)
-
-			if len(noc) > 0:
-				if "BMC of mgmt node" in noc:
-					warns.append("- %s - %s." % (bname, noc))
-				else:
-					errs.append("- %s - %s." % (bname, noc))
-
-		# Print out the Node BMC info.
-		if len(errs) > 0:
-			numErrs += 1
-			print("  NodeBMCs: FAIL")
-			for emsg in errs:
-				print("    %s" % (emsg))
-
-		if len(warns) > 0:
-			print("  NodeBMCs: WARNING")
-			for emsg in warns:
-				print("    %s" % (emsg))
-
-		if not errs and not warns:
-			print("  NodeBMCs: PASS")
+        # Print out the node info.
+        if not errs:
+            print("  Nodes: PASS")
+        else:
+            numErrs += 1
+            print("  Nodes: FAIL")
+            for emsg in errs:
+                print("    %s" % (emsg))
 
 
-		# Iterate RouterBMCs in SLS.  Easy since SLS data contains these
-		# directly.  Check for comps/RFEP/mgmt ports.  Mismatches == FAIL.
+        # Iterate NodeBMCs in SLS.  This is tricky, the SLS data doesn't have
+        # node BMCs, need to infer them from the nodes using the Parent field.
+        # Check for presence in comps/RFEPs and mgmt ports, mismatches == FAIL.
+        # If no mgmt port, check if it's a mgmt NCN and if so, report it as
+        # info.
 
-		errs = []
+        errs = []
+        warns = []
+        mappedComps = {}
 
-		rtrs = list(filter(lambda f: (f['TypeString'] == "RouterBMC"), slsJSON))
-		for comp in rtrs:
-			bname = comp['Xname']
-			if not bname.startswith(cab.xname):
-				continue
+        for comp in nodes:
+            if not comp['Xname'].startswith(cab.xname):
+                continue
 
-			noc = doChecks(cab.xclass, comp, bname, "RouterBMC", compJSON, rfepJSON, slsJSON)
+            bname = comp['Parent']
+            if bname in mappedComps:
+                continue
 
-			if len(noc) > 0:
-				errs.append("- %s - %s." % (bname, noc))
+            mappedComps[bname] = True
+            noc = doChecks(cab.xclass, comp, bname, "NodeBMC", compJSON, rfepJSON, slsJSON)
 
-		# Print out the Node BMC info.
-		if not errs:
-			print("  RouterBMCs: PASS")
-		else:
-			numErrs += 1
-			print("  RouterBMCs: FAIL")
-			for emsg in errs:
-				print("    %s" % (emsg))
+            if len(noc) > 0:
+                if "BMC of mgmt node" in noc:
+                    warns.append("- %s - %s." % (bname, noc))
+                else:
+                    errs.append("- %s - %s." % (bname, noc))
 
+        # Print out the Node BMC info.
+        if len(errs) > 0:
+            numErrs += 1
+            print("  NodeBMCs: FAIL")
+            for emsg in errs:
+                print("    %s" % (emsg))
 
-		# Iterate ChassisBMCs in SLS.  These are really GB CMCs.
+        if len(warns) > 0:
+            print("  NodeBMCs: WARNING")
+            for emsg in warns:
+                print("    %s" % (emsg))
 
-		errs = []
-
-		rtrs = list(filter(lambda f: (f['TypeString'] == "ChassisBMC"), slsJSON))
-		for comp in rtrs:
-			bname = comp['Xname']
-			if not bname.startswith(cab.xname):
-				continue
-
-			noc = doChecks(cab.xclass, comp, bname, "ChassisBMC", compJSON, rfepJSON, slsJSON)
-
-			if len(noc) > 0:
-				errs.append("- %s - %s." % (bname, noc))
-
-		# Print out the Node BMC info.
-		if not errs:
-			print("  ChassisBMCs/CMCs: PASS")
-		else:
-			numErrs += 1
-			print("  ChassisBMCs/CMCs: FAIL")
-			for emsg in errs:
-				print("    %s" % (emsg))
+        if not errs and not warns:
+            print("  NodeBMCs: PASS")
 
 
-		# Check CabPDUControllers in SLS.  Check comps/RFEP.  Mgmt port?
-		# Mismatches are WARNING.
+        # Iterate RouterBMCs in SLS.  Easy since SLS data contains these
+        # directly.  Check for comps/RFEP/mgmt ports.  Mismatches == FAIL.
 
-		errs = []
+        errs = []
 
-		pdus = list(filter(lambda f: (f['TypeString'] == "CabinetPDUController"), slsJSON))
-		for comp in pdus:
-			bname = comp['Xname']
-			if not bname.startswith(cab.xname):
-				continue
+        rtrs = list(filter(lambda f: (f['TypeString'] == "RouterBMC"), slsJSON))
+        for comp in rtrs:
+            bname = comp['Xname']
+            if not bname.startswith(cab.xname):
+                continue
 
-			noc = doChecks(cab.xclass, comp, bname, "CabinetPDUController", compJSON, rfepJSON, slsJSON)
-			if len(noc) > 0:
-				errs.append("- %s - %s." % (bname, noc))
+            noc = doChecks(cab.xclass, comp, bname, "RouterBMC", compJSON, rfepJSON, slsJSON)
 
-		# Print out the Node BMC info.
-		if not errs:
-			print("  CabinetPDUControllers: PASS")
-		else:
-			print("  CabinetPDUControllers: WARNING")
-			for emsg in errs:
-				print("    %s" % (emsg))
+            if len(noc) > 0:
+                errs.append("- %s - %s." % (bname, noc))
+
+        # Print out the Node BMC info.
+        if not errs:
+            print("  RouterBMCs: PASS")
+        else:
+            numErrs += 1
+            print("  RouterBMCs: FAIL")
+            for emsg in errs:
+                print("    %s" % (emsg))
+
+
+        # Iterate ChassisBMCs in SLS.  These are really GB CMCs.
+
+        errs = []
+
+        rtrs = list(filter(lambda f: (f['TypeString'] == "ChassisBMC"), slsJSON))
+        for comp in rtrs:
+            bname = comp['Xname']
+            if not bname.startswith(cab.xname):
+                continue
+
+            noc = doChecks(cab.xclass, comp, bname, "ChassisBMC", compJSON, rfepJSON, slsJSON)
+
+            if len(noc) > 0:
+                errs.append("- %s - %s." % (bname, noc))
+
+        # Print out the Node BMC info.
+        if not errs:
+            print("  ChassisBMCs/CMCs: PASS")
+        else:
+            numErrs += 1
+            print("  ChassisBMCs/CMCs: FAIL")
+            for emsg in errs:
+                print("    %s" % (emsg))
+
+
+        # Check CabPDUControllers in SLS.  Check comps/RFEP.  Mgmt port?
+        # Mismatches are WARNING.
+
+        errs = []
+
+        pdus = list(filter(lambda f: (f['TypeString'] == "CabinetPDUController"), slsJSON))
+        for comp in pdus:
+            bname = comp['Xname']
+            if not bname.startswith(cab.xname):
+                continue
+
+            noc = doChecks(cab.xclass, comp, bname, "CabinetPDUController", compJSON, rfepJSON, slsJSON)
+            if len(noc) > 0:
+                errs.append("- %s - %s." % (bname, noc))
+
+        # Print out the Node BMC info.
+        if not errs:
+            print("  CabinetPDUControllers: PASS")
+        else:
+            print("  CabinetPDUControllers: WARNING")
+            for emsg in errs:
+                print("    %s" % (emsg))
 
 
 
-	print("")
-	return numErrs
+    print("")
+    return numErrs
 
 
 # Generate Mountain/Hill cabinet detailed report.
 
 def genMountainDetails(slsData, compData, rfepData):
-	numErrs = 0
+    numErrs = 0
 
-	slsJSON = json.loads(slsData)
-	compJSON = json.loads(compData)
-	rfepJSON = json.loads(rfepData)
+    slsJSON = json.loads(slsData)
+    compJSON = json.loads(compData)
+    rfepJSON = json.loads(rfepData)
 
-	cabList = getCabList(slsData)
-	# Sort by cab num
-	clSorted = sorted(cabList, key=lambda cab: cab.xname)
+    cabList = getCabList(slsData)
+    # Sort by cab num
+    clSorted = sorted(cabList, key=lambda cab: cab.xname)
 
-	print("Mountain/Hill Cabinet Checks")
-	print("============================")
+    print("Mountain/Hill Cabinet Checks")
+    print("============================")
 
-	numCabs = 0
+    numCabs = 0
 
-	for cab in clSorted:
-		# For each cab, filter for river class, ignore mountain/hill.
-		if cab.xclass == "River":
-			continue
+    for cab in clSorted:
+        # For each cab, filter for river class, ignore mountain/hill.
+        if cab.xclass == "River":
+            continue
 
-		numCabs += 1
-		print("%s (%s)" % (cab.xname, cab.xclass))
-
-
-		# Check ChassisBMCs.  All 8 must be present in each cabinet for
-		# Mountain, c1 and c3 must be present for Hill.  NOTE!!!  It is assumed
-		# that the SLS data contains all requisite ChassisBMCs and this app
-		# does not have to verify the counts or e.g. that c1 and c3 are both
-		# present in SLS for Hill.
-
-		errs = []
-		nodes = list(filter(lambda f: (f['TypeString'] == "ChassisBMC"), slsJSON))
-		for comp in nodes:
-			# ChassisBMC names in SLS and HSM components don't have the 'bX'
-			# suffix, but they do in the RFEP data.  Yuck, can't use the
-			# convenience func...
-			bname = comp['Xname']
-			if not bname.startswith(cab.xname):
-				continue
-
-			noc = ""
-
-			# Check state components presence
-			flds = compJSON['Components']
-			filtered = list(filter(lambda f: (f['ID'] == bname), flds))
-			if not filtered:
-				noc = "Not found in HSM Components"
-
-			# Check RF Endpoints presence
-			flds = rfepJSON['RedfishEndpoints']
-			filtered = list(filter(lambda f: (f['ID'] == bname+"b0"), flds))
-			if not filtered:
-				if len(noc) > 0:
-					noc += "; "
-				noc += "Not found in HSM Redfish Endpoints"
+        numCabs += 1
+        print("%s (%s)" % (cab.xname, cab.xclass))
 
 
-			if len(noc) > 0:
-				errs.append("- %s - %s." % (bname, noc))
+        # Check ChassisBMCs.  All 8 must be present in each cabinet for
+        # Mountain, c1 and c3 must be present for Hill.  NOTE!!!  It is assumed
+        # that the SLS data contains all requisite ChassisBMCs and this app
+        # does not have to verify the counts or e.g. that c1 and c3 are both
+        # present in SLS for Hill.
 
-		# Print out the Chassis BMC info.
-		if not errs:
-			print("  ChassisBMCs: PASS")
-		else:
-			numErrs += 1
-			print("  ChassisBMCs: FAIL")
-			for emsg in errs:
-				print("    %s" % (emsg))
+        errs = []
+        nodes = list(filter(lambda f: (f['TypeString'] == "ChassisBMC"), slsJSON))
+        for comp in nodes:
+            # ChassisBMC names in SLS and HSM components don't have the 'bX'
+            # suffix, but they do in the RFEP data.  Yuck, can't use the
+            # convenience func...
+            bname = comp['Xname']
+            if not bname.startswith(cab.xname):
+                continue
 
+            noc = ""
 
-		# Check Nodes.  Missing == WARNING.
+            # Check state components presence
+            flds = compJSON['Components']
+            filtered = list(filter(lambda f: (f['ID'] == bname), flds))
+            if not filtered:
+                noc = "Not found in HSM Components"
 
-		# Iterate all nodes in SLS.  Check for not present in comps/rfeps,
-		# mgmt ports.  Any missing/mismatch is a FAIL.
-
-		errs = []
-		nodes = list(filter(lambda f: (f['TypeString'] == "Node"), slsJSON))
-		for comp in nodes:
-			bname = comp['Xname']
-			if not bname.startswith(cab.xname):
-				continue
-
-			flds = compJSON['Components']
-			filtered = list(filter(lambda f: (f['ID'] == comp['Xname']), flds))
-			if not filtered:
-				errs.append("- %s (%s, NID %d) - Not found in HSM Components." %
-					(comp['Xname'], comp['ExtraProperties']['Role'],
-					comp['ExtraProperties']['NID']))
-
-		# Print out the node info.
-		if not errs:
-			print("  Nodes: PASS")
-		else:
-			print("  Nodes: WARNING")
-			for emsg in errs:
-				print("    %s" % (emsg))
+            # Check RF Endpoints presence
+            flds = rfepJSON['RedfishEndpoints']
+            filtered = list(filter(lambda f: (f['ID'] == bname+"b0"), flds))
+            if not filtered:
+                if len(noc) > 0:
+                    noc += "; "
+                noc += "Not found in HSM Redfish Endpoints"
 
 
-		# Check NodeBMCs.  Missing == WARNING.  This is tricky, the SLS data
-		# doesn't have node BMCs, need to infer them from the nodes using the
-		# Parent field.  Check for presence in comps/RFEPs and mgmt ports,
-		# mismatches == WARNING.
-		# if so, report it as info.
+            if len(noc) > 0:
+                errs.append("- %s - %s." % (bname, noc))
 
-		errs = []
-		mappedComps = {}
-
-		for comp in nodes:
-			if not comp['Xname'].startswith(cab.xname):
-				continue
-
-			bname = comp['Parent']
-			if bname in mappedComps:
-				continue
-
-			mappedComps[bname] = True
-			noc = doChecks(cab.xclass, comp, bname, "NodeBMC", compJSON, rfepJSON, slsJSON)
-
-			if len(noc) > 0:
-				errs.append("- %s - %s." % (bname, noc))
-
-		# Print out the Node BMC info.
-		if not errs:
-			print("  NodeBMCs: PASS")
-		else:
-			print("  NodeBMCs: WARNING")
-			for emsg in errs:
-				print("    %s" % (emsg))
+        # Print out the Chassis BMC info.
+        if not errs:
+            print("  ChassisBMCs: PASS")
+        else:
+            numErrs += 1
+            print("  ChassisBMCs: FAIL")
+            for emsg in errs:
+                print("    %s" % (emsg))
 
 
-		# Check RouterBMCs.  Missing == WARNING.
+        # Check Nodes.  Missing == WARNING.
 
-		errs = []
-		nodes = list(filter(lambda f: (f['TypeString'] == "RouterBMC"), slsJSON))
-		for comp in nodes:
-			bname = comp['Xname']
-			if not bname.startswith(cab.xname):
-				continue
+        # Iterate all nodes in SLS.  Check for not present in comps/rfeps,
+        # mgmt ports.  Any missing/mismatch is a FAIL.
 
-			noc = doChecks(cab.xclass, comp, bname, "RouterBMC", compJSON, rfepJSON, slsJSON)
-			if len(noc) > 0:
-				errs.append("- %s - %s." % (bname, noc))
+        errs = []
+        nodes = list(filter(lambda f: (f['TypeString'] == "Node"), slsJSON))
+        for comp in nodes:
+            bname = comp['Xname']
+            if not bname.startswith(cab.xname):
+                continue
 
-		# Print out the Chassis BMC info.
-		if not errs:
-			print("  RouterBMCs: PASS")
-		else:
-			numErrs += 1
-			print("  RouterBMCs: FAIL")
-			for emsg in errs:
-				print("    %s" % (emsg))
+            flds = compJSON['Components']
+            filtered = list(filter(lambda f: (f['ID'] == comp['Xname']), flds))
+            if not filtered:
+                errs.append("- %s (%s, NID %d) - Not found in HSM Components." %
+                    (comp['Xname'], comp['ExtraProperties']['Role'],
+                    comp['ExtraProperties']['NID']))
 
-	if numCabs == 0:
-		print("None Found.")
+        # Print out the node info.
+        if not errs:
+            print("  Nodes: PASS")
+        else:
+            print("  Nodes: WARNING")
+            for emsg in errs:
+                print("    %s" % (emsg))
 
-	print("")
-	return numErrs
+
+        # Check NodeBMCs.  Missing == WARNING.  This is tricky, the SLS data
+        # doesn't have node BMCs, need to infer them from the nodes using the
+        # Parent field.  Check for presence in comps/RFEPs and mgmt ports,
+        # mismatches == WARNING.
+        # if so, report it as info.
+
+        errs = []
+        mappedComps = {}
+
+        for comp in nodes:
+            if not comp['Xname'].startswith(cab.xname):
+                continue
+
+            bname = comp['Parent']
+            if bname in mappedComps:
+                continue
+
+            mappedComps[bname] = True
+            noc = doChecks(cab.xclass, comp, bname, "NodeBMC", compJSON, rfepJSON, slsJSON)
+
+            if len(noc) > 0:
+                errs.append("- %s - %s." % (bname, noc))
+
+        # Print out the Node BMC info.
+        if not errs:
+            print("  NodeBMCs: PASS")
+        else:
+            print("  NodeBMCs: WARNING")
+            for emsg in errs:
+                print("    %s" % (emsg))
+
+
+        # Check RouterBMCs.  Missing == WARNING.
+
+        errs = []
+        nodes = list(filter(lambda f: (f['TypeString'] == "RouterBMC"), slsJSON))
+        for comp in nodes:
+            bname = comp['Xname']
+            if not bname.startswith(cab.xname):
+                continue
+
+            noc = doChecks(cab.xclass, comp, bname, "RouterBMC", compJSON, rfepJSON, slsJSON)
+            if len(noc) > 0:
+                errs.append("- %s - %s." % (bname, noc))
+
+        # Print out the Chassis BMC info.
+        if not errs:
+            print("  RouterBMCs: PASS")
+        else:
+            numErrs += 1
+            print("  RouterBMCs: FAIL")
+            for emsg in errs:
+                print("    %s" % (emsg))
+
+    if numCabs == 0:
+        print("None Found.")
+
+    print("")
+    return numErrs
 
 
 # Entry point
 
 def main():
-	authToken = getAuthenticationToken()
-	if authToken == "":
-		print("ERROR: No/empty auth token, can't continue.")
-		return 1
+    authToken = getAuthenticationToken()
+    if authToken == "":
+        print("ERROR: No/empty auth token, can't continue.")
+        return 1
 
-	compData, stat = getHSMComponents(authToken)
-	if stat != 0:
-		print("HSM components returned non-zero.")
-		return 1
+    compData, stat = getHSMComponents(authToken)
+    if stat != 0:
+        print("HSM components returned non-zero.")
+        return 1
 
-	rfepData, stat = getHSMRFEP(authToken)
-	if stat != 0:
-		print("HSM RFEPs returned non-zero.")
-		return 1
+    rfepData, stat = getHSMRFEP(authToken)
+    if stat != 0:
+        print("HSM RFEPs returned non-zero.")
+        return 1
 
-	slsData, stat = getSLSHWData(authToken)
-	if stat != 0:
-		print("SLS data returned non-zero.")
-		return 1
+    slsData, stat = getSLSHWData(authToken)
+    if stat != 0:
+        print("SLS data returned non-zero.")
+        return 1
 
-	genSummary(slsData, compData)
-	numErrs =  genRiverDetails(slsData, compData, rfepData)
-	numErrs += genMountainDetails(slsData, compData, rfepData)
+    genSummary(slsData, compData)
+    numErrs =  genRiverDetails(slsData, compData, rfepData)
+    numErrs += genMountainDetails(slsData, compData, rfepData)
 
-	if numErrs > 0:
-		return 1
+    if numErrs > 0:
+        return 1
 
-	return 0
+    return 0
 
 if __name__ == "__main__":
-	ret = main()
-	exit(ret)
+    ret = main()
+    exit(ret)

--- a/scripts/networking/DNS/README-dns_records.md
+++ b/scripts/networking/DNS/README-dns_records.md
@@ -1,9 +1,9 @@
 # ./dns_records.py - View, add, delete or modify system DNS records
 Use ./dns_records.py to view (-p), modify (requires -f) and delete (-x -f) statically defined records in DNS. 
 
-System DNS records come either dynamically from DHCP (Kea and SMD) or may be defined statically via SLS.  Records in SLS /networks are picked up by the DNS manager every 2 minutes and added to DNS.   This utility provides a better visual reference and more safety nets than modifying SLS records via dumpstate/loadstate and JSON.
+System DNS records come either dynamically from DHCP (Kea and SMD) or may be defined statically via SLS.  Records in SLS /networks are picked up by the DNS manager every 2 minutes and added to DNS.  This utility provides a better visual reference and more safety nets than modifying SLS records via dumpstate/loadstate and JSON.
 
-## Usage:
+## Usage
 ### Help
 ```
 ./dns_records.py
@@ -31,7 +31,7 @@ System DNS records come either dynamically from DHCP (Kea and SMD) or may be def
 ./dns_records -i <IPv4 Address> <Name/A> <Alias/CNAME list>" -x -f
 ```
 
-## Example Workflow to modify a record:
+## Example Workflow to modify a record
 In this example we want to add an alias of "api-gateway-test" to the existing istio api gateway record at 10.92.100.71.
 
 ### Query Existing
@@ -65,7 +65,7 @@ Cowardly refusing to update without -f
 ```
 
 ### Accept the Change
-The above test showed that the record existed and presented the new record that would be added.  However, as a safety we need to "force" the change with -f (as stated in the output).
+The above test showed that the record existed and presented the new record that would be added.  However, as a safety we need to "force" the change with `-f` (as stated in the output).
 ```
 # ./dns_records.py -i "      10.92.100.71 istio-ingressgateway api-gw-service packages registry spire.local api_gw_service api_gw_service.local  registry.local packages packages.local spire api-gateway-test" -f
 New record:       10.92.100.71 istio-ingressgateway api-gw-service packages registry spire.local api_gw_service api_gw_service.local  registry.local packages packages.local spire api-gateway-test
@@ -76,4 +76,4 @@ Updated reservation record in network structure (-f): NMNLB
 Replaced existing reservation record in SLS
 ```
 
-NOTE: DNS will pick up this new record in 2 min or less.
+NOTE: DNS will pick up this new record in 2 minutes or less.


### PR DESCRIPTION
(cherry picked from commit d15f193674b3ba3e99415de8c8cea83886e6e5ec)

Backport of https://github.com/Cray-HPE/hpe-csm-scripts/pull/40

I don't plan to make a manifest PR for this backport, but if we ever do need to make changes to this RPM in this release, may as well pull in these harmless fixes as well at that time.

* [1.4 backport PR](https://github.com/Cray-HPE/hpe-csm-scripts/pull/41)
* [1.3 backport PR](https://github.com/Cray-HPE/hpe-csm-scripts/pull/42)
* [1.0 backport PR](https://github.com/Cray-HPE/hpe-csm-scripts/pull/44)
* [0.9 backport PR](https://github.com/Cray-HPE/hpe-csm-scripts/pull/45)