### PR TITLE
CASMINST-5969: Linting of minor language and formatting errors

### DIFF
--- a/scripts/networking/DNS/README-dns_records.md
+++ b/scripts/networking/DNS/README-dns_records.md
@@ -1,9 +1,9 @@
 # ./dns_records.py - View, add, delete or modify system DNS records
 Use ./dns_records.py to view (-p), modify (requires -f) and delete (-x -f) statically defined records in DNS. 
 
-System DNS records come either dynamically from DHCP (Kea and SMD) or may be defined statically via SLS.  Records in SLS /networks are picked up by the DNS manager every 2 minutes and added to DNS.   This utility provides a better visual reference and more safety nets than modifying SLS records via dumpstate/loadstate and JSON.
+System DNS records come either dynamically from DHCP (Kea and SMD) or may be defined statically via SLS.  Records in SLS /networks are picked up by the DNS manager every 2 minutes and added to DNS.  This utility provides a better visual reference and more safety nets than modifying SLS records via dumpstate/loadstate and JSON.
 
-## Usage:
+## Usage
 ### Help
 ```
 ./dns_records.py
@@ -31,7 +31,7 @@ System DNS records come either dynamically from DHCP (Kea and SMD) or may be def
 ./dns_records -i <IPv4 Address> <Name/A> <Alias/CNAME list>" -x -f
 ```
 
-## Example Workflow to modify a record:
+## Example Workflow to modify a record
 In this example we want to add an alias of "api-gateway-test" to the existing istio api gateway record at 10.92.100.71.
 
 ### Query Existing
@@ -65,7 +65,7 @@ Cowardly refusing to update without -f
 ```
 
 ### Accept the Change
-The above test showed that the record existed and presented the new record that would be added.  However, as a safety we need to "force" the change with -f (as stated in the output).
+The above test showed that the record existed and presented the new record that would be added.  However, as a safety we need to "force" the change with `-f` (as stated in the output).
 ```
 # ./dns_records.py -i "      10.92.100.71 istio-ingressgateway api-gw-service packages registry spire.local api_gw_service api_gw_service.local  registry.local packages packages.local spire api-gateway-test" -f
 New record:       10.92.100.71 istio-ingressgateway api-gw-service packages registry spire.local api_gw_service api_gw_service.local  registry.local packages packages.local spire api-gateway-test
@@ -76,4 +76,4 @@ Updated reservation record in network structure (-f): NMNLB
 Replaced existing reservation record in SLS
 ```
 
-NOTE: DNS will pick up this new record in 2 min or less.
+NOTE: DNS will pick up this new record in 2 minutes or less.


### PR DESCRIPTION
(cherry picked from commit d15f193674b3ba3e99415de8c8cea83886e6e5ec)

Backport of https://github.com/Cray-HPE/hpe-csm-scripts/pull/40

I don't plan to make a manifest PR for this backport, but if we ever do need to make changes to this RPM in this release, may as well pull in these harmless fixes as well at that time.

* [1.4 backport PR](https://github.com/Cray-HPE/hpe-csm-scripts/pull/41)
* [1.3 backport PR](https://github.com/Cray-HPE/hpe-csm-scripts/pull/42)
* [1.2 backport PR](https://github.com/Cray-HPE/hpe-csm-scripts/pull/43)
* [1.0 backport PR](https://github.com/Cray-HPE/hpe-csm-scripts/pull/44)
