### PR TITLE
CASMHMS-5930 Add support for CAPMC hardware checks to test wrappers

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,18 @@
 # Changelog
 
-## [0.4.6] - 2023-02-03
+## [0.5.3] - 2023-03-02
+### Changed
+- Move CAPMC get_power_cap_capabilities test into hardware checks stage.
+
+## [0.5.2] - 2023-02-22
+### Changed
+- Linting of minor language and formatting errors.
+
+## [0.5.1] - 2023-02-10
+### Changed
+- Improved argument parsing for set-bmc-ntp-dns.sh.
+
+## [0.5.0] - 2023-02-03
 ### Changed
 - Moved hardware-sensitive CT tests into separate stage.
 

--- a/scripts/hms_verification/run_hardware_checks.sh
+++ b/scripts/hms_verification/run_hardware_checks.sh
@@ -47,6 +47,12 @@ trap 'if [[ -f ${LOG_PATH} ]]; then \
       fi; \
       exit 1' SIGHUP SIGINT SIGTERM
 
+# service name, helm deployment, helm filter args
+CAPMC_ARR=("capmc" "cray-hms-capmc" "name=cray-hms-capmc-check-hardware")
+HSM_ARR=("hsm" "cray-hms-smd" "name=cray-hms-smd-check-hardware")
+
+ALL_ARR=("${CAPMC_ARR[@]}" "${HSM_ARR[@]}")
+
 DATE_TIME=$(date +"%Y%m%dT%H%M%S")
 LOG_PATH="/opt/cray/tests/hardware_checks-${DATE_TIME}.log"
 
@@ -65,37 +71,98 @@ fi
 
 echo "Log file for run is: ${LOG_PATH}"
 
+NUM_TEST_SERVICES=0
 echo "Running hardware checks..."
-helm test -n services cray-hms-smd --filter name=cray-hms-smd-check-hardware > ${LOG_PATH} 2>&1
+for i in $(seq 0 3 $((${#ALL_ARR[@]} - 1))); do
+    TEST_DEPLOYMENT=${ALL_ARR[$((${i} + 1))]}
+    FILTER_ARGS=${ALL_ARR[$((${i} + 2))]}
+    helm test -n services ${TEST_DEPLOYMENT} --filter ${FILTER_ARGS} >> ${LOG_PATH} 2>&1 &
+    ((NUM_TEST_SERVICES++))
+done
+wait
+
 echo "DONE."
 
 if [[ -r "${LOG_PATH}" ]]; then
+    # post-processing for log file readability
+    sed -i '/NAME:/{x;p;x;}' "${LOG_PATH}"
+    sed -i '/^$/{1d;}' "${LOG_PATH}"
     echo "" >> "${LOG_PATH}"
-    TEST_OUTPUT=$(cat "${LOG_PATH}")
+    ALL_OUTPUT=$(cat "${LOG_PATH}")
 else
     echo "ERROR: missing readable test output file: ${LOG_PATH}"
     exit 1
 fi
 
-# parse hardware check output
-TEST_SUITE_HW_CHECK_OUTPUT=$(echo "${TEST_OUTPUT}" | sed -n '/TEST SUITE:.*cray-hms-smd-check-hardware/,/Phase:/p')
-if [[ -z "${TEST_SUITE_HW_CHECK_OUTPUT}" ]]; then
-    print_and_log "ERROR: cray-hms-smd-check-hardware checks didn't appear to run"
-else
-    TEST_SUITE_HW_CHECK_PARSE_CHECK=$(echo "${TEST_SUITE_HW_CHECK_OUTPUT}" | grep -E "TEST SUITE:" | wc -l | tr -d " ")
-    if [[ ${TEST_SUITE_HW_CHECK_PARSE_CHECK} -ne 1 ]]; then
-        print_and_log "ERROR: failed to parse Helm output for cray-hms-smd-check-hardware data"
-        # ensure invalid data is not processed
-        TEST_SUITE_HW_CHECK_OUTPUT=""
-    fi
+# check for output from Helm test
+HELM_OUTPUT_CHECK=$(echo "${ALL_OUTPUT}" | grep -E "TEST SUITE:")
+if [[ -z "${HELM_OUTPUT_CHECK}" ]]; then
+    print_and_log "ERROR: failed to parse Helm output for test data"
+    exit 1
 fi
-TEST_SUITE_HW_CHECK_PASS_CHECK=$(echo "${TEST_SUITE_HW_CHECK_OUTPUT}" | grep -E "Phase:.*Succeeded" | wc -l | tr -d " ")
 
-# print results
-if [[ ${TEST_SUITE_HW_CHECK_PASS_CHECK} -eq 1 ]]; then
-    print_and_log "SUCCESS: Hardware checks passed"
+# initialize variables
+SERVICES_PASSED=""
+SERVICES_FAILED=""
+NUM_SERVICES_PASSED=0
+NUM_SERVICES_FAILED=0
+
+# evaluate which tests passed and failed
+for i in $(seq 0 3 $((${#ALL_ARR[@]} - 1))); do
+    # data for service being tested
+    TEST_SERVICE=${ALL_ARR[${i}]}
+    TEST_DEPLOYMENT=${ALL_ARR[$((${i} + 1))]}
+    NUM_TESTS_EXPECTED=1
+    NUM_TESTS_PASSED=0
+
+    # parse hardware check output
+    TEST_SUITE_HW_CHECK_OUTPUT=$(echo "${ALL_OUTPUT}" | sed -n '/TEST SUITE:.*'${TEST_DEPLOYMENT}'-check-hardware/,/Phase:/p')
+    if [[ -z "${TEST_SUITE_HW_CHECK_OUTPUT}" ]]; then
+        print_and_log "ERROR: ${TEST_DEPLOYMENT}-check-hardware tests didn't appear to run"
+    else
+        TEST_SUITE_HW_CHECK_PARSE_CHECK=$(echo "${TEST_SUITE_HW_CHECK_OUTPUT}" | grep -E "TEST SUITE:" | wc -l | tr -d " ")
+        if [[ ${TEST_SUITE_HW_CHECK_PARSE_CHECK} -ne 1 ]]; then
+            print_and_log "ERROR: failed to parse Helm output for ${TEST_DEPLOYMENT}-check-hardware data"
+            # ensure invalid data is not processed
+            TEST_SUITE_HW_CHECK_OUTPUT=""
+        fi
+    fi
+
+    TEST_SUITE_HW_CHECK_PASS_CHECK=$(echo "${TEST_SUITE_HW_CHECK_OUTPUT}" | grep -E "Phase:.*Succeeded" | wc -l | tr -d " ")
+    if [[ ${TEST_SUITE_HW_CHECK_PASS_CHECK} -eq 1 ]]; then
+        ((NUM_TESTS_PASSED++))
+    fi
+
+    # track the test result
+    if [[ ${NUM_TESTS_PASSED} -eq ${NUM_TESTS_EXPECTED} ]]; then
+        ((NUM_SERVICES_PASSED++))
+        if [[ -z ${SERVICES_PASSED} ]]; then
+            SERVICES_PASSED="${TEST_SERVICE}"
+        else
+            SERVICES_PASSED="${SERVICES_PASSED}, ${TEST_SERVICE}"
+        fi
+    else
+        ((NUM_SERVICES_FAILED++))
+        if [[ -z ${SERVICES_FAILED} ]]; then
+            SERVICES_FAILED="${TEST_SERVICE}"
+        else
+            SERVICES_FAILED="${SERVICES_FAILED}, ${TEST_SERVICE}"
+        fi
+    fi
+done
+
+# print test results
+if [[ ${NUM_SERVICES_FAILED} -eq 0 ]]; then
+    print_and_log "SUCCESS: All ${NUM_TEST_SERVICES} hardware checks passed: ${SERVICES_PASSED}"
     exit 0
+elif [[ ${NUM_SERVICES_PASSED} -eq 0 ]]; then
+    print_and_log "FAILURE: All ${NUM_TEST_SERVICES} hardware checks FAILED: ${SERVICES_FAILED}"
+    exit 1
 else
-    print_and_log "FAILURE: Hardware checks FAILED"
+    if [[ ${NUM_SERVICES_FAILED} -eq 1 ]] ; then
+        print_and_log "FAILURE: ${NUM_SERVICES_FAILED} hardware check FAILED (${SERVICES_FAILED}), ${NUM_SERVICES_PASSED} passed (${SERVICES_PASSED})"
+    else
+        print_and_log "FAILURE: ${NUM_SERVICES_FAILED} hardware checks FAILED (${SERVICES_FAILED}), ${NUM_SERVICES_PASSED} passed (${SERVICES_PASSED})"
+    fi
     exit 1
 fi

--- a/scripts/hms_verification/run_hms_ct_tests.sh
+++ b/scripts/hms_verification/run_hms_ct_tests.sh
@@ -55,7 +55,7 @@ trap 'if [[ -f ${LOG_PATH} ]]; then \
 
 # service name, helm deployment, smoke tests bool, functional tests bool, helm filter args
 BSS_ARR=("bss" "cray-hms-bss" 1 1 "none")
-CAPMC_ARR=("capmc" "cray-hms-capmc" 1 1 "none")
+CAPMC_ARR=("capmc" "cray-hms-capmc" 1 1 "name=cray-hms-capmc-test-smoke,name=cray-hms-capmc-test-functional")
 FAS_ARR=("fas" "cray-hms-firmware-action" 1 1 "none")
 HBTD_ARR=("hbtd" "cray-hms-hbtd" 1 0 "none")
 HMNFD_ARR=("hmnfd" "cray-hms-hmnfd" 1 0 "none")


### PR DESCRIPTION
### Summary and Scope

This change adds support for CAPMC hardware checks to the HMS test wrapper scripts. Previously the only tests in the hardware checks test stage were HSM tests, but now there are additional tests for CAPMC get_power_cap_capabilities. Update the wrapper scripts to execute and parse the results of these tests accordingly.

### Issues and Related PRs

* Resolves CASMHMS-5930.

### Testing

This change was tested on Surtur by deploying the new version of CAPMC, running the new versions of the wrapper scripts, and verifying that the get_power_cap_capabilities CT test was no longer included in the set of functional tests executed as well as that it instead ran as part of the hardware checks test stage.

Was a fresh Install tested? N
Was an Upgrade tested? Y
Was a Downgrade tested? Y

### Risks and Mitigations

Low risk.