### PR TITLE
CASMHMS-5944 Add -p option to HMS CT test wrapper to print pod logs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## [0.5.4] - 2023-03-20
+### Changed
+- Added option to print failed pod logs to HMS CT test wrapper.
+
 ## [0.5.3] - 2023-03-02
 ### Changed
-- Move CAPMC get_power_cap_capabilities test into hardware checks stage.
+- Moved CAPMC get_power_cap_capabilities test into hardware checks stage.
 
 ## [0.5.2] - 2023-02-22
 ### Changed


### PR DESCRIPTION
### Summary and Scope

This change adds a '-p' command line option to the HMS CT test wrapper script that will print the logs of failed test pods to stdout at the end of the test run. By default it is not enabled since we only want to print the test run summary under normal conditions during CSM installs and upgrades. We plan to enable this option in the vShasta CI/CD pipeline when executing under goss so that more debugging output can be collected when failures occur.

### Issues and Related PRs

* Resolves CASMHMS-5944.

### Testing

This change was tested on Dorian by executing different sets of HMS CT tests using the updated wrapper script and verifying that the correct pods logs were printed under various conditions.

Was a fresh Install tested? Y
Was an Upgrade tested? N
Was a Downgrade tested? N

### Risks and Mitigations

Low risk.