### PR TITLE
CASMHMS-6057 Only run REDS CT when not in vShasta

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.6.1] - 2023-07-28
+### Changed
+- Added check for vShasta to run_hms_ct_tests.sh
+
 ## [0.6.0] - 2023-07-05
 ### Changed
 - Added HMNFD Tavern tests to HMS CT test wrapper.


### PR DESCRIPTION
## Summary and Scope

REDS is not installed in the vShasta environment but the CT still runs against it. Only execute the REDS CT if we are not in vShasta.

## Issues and Related PRs

* Resolves [CASMHMS-6057](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6057)

## Testing
### Tested on:

  * `gamora`

### Test description:

Executed the script to show that the REDS CT ran. Touched the /etc/google_system file and re-ran showing that the REDS CT was skipped. Removed /etc/google_system file and the REDS CT again executed.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? Y
- Was upgrade tested? If not, why? N - just ran the script, did not install the RPM
- Was downgrade tested? If not, why? N - just ran the script, did not install the RPM
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

No known risks.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

