### PR TITLE
CASMINST-3431 Build for noos

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),
@@ -51,61 +51,66 @@ pipeline {
         VERSION = sh(returnStdout: true, script: "git describe --tags | tr -s '-' '~' | sed 's/^v//'").trim()
     }
 
+
     stages {
 
-        stage('Prepare: RPMs') {
-            agent {
-                docker {
-                    label "${PRIMARY_NODE}"
-                    reuseNode true
-                    image "${sleImage}"
-                }
-            }
-            steps {
-                runLibraryScript("addRpmMetaData.sh", "${env.NAME}.spec")
-                sh "make prepare"
-                sh "git update-index --assume-unchanged ${env.NAME}.spec"
-            }
-        }
+        stage('Build & Publish') {
 
-        stage('Build: RPMs') {
-            agent {
-                docker {
-                    label "${PRIMARY_NODE}"
-                    reuseNode true
-                    image "${sleImage}"
-                }
-            }
-            steps {
-                sh "make rpm"
-            }
-        }
+            stages {
 
-        stage('Publish: RPMs') {
-            agent {
-                docker {
-                    label "${PRIMARY_NODE}"
-                    reuseNode true
-                    args "-v /home/jenkins/.ssh:/home/jenkins/.ssh"
-                    image "${sleImage}"
+                stage('Prepare: RPMs') {
+                    agent {
+                        docker {
+                            label "${PRIMARY_NODE}"
+                            reuseNode true
+                            image "${sleImage}"
+                        }
+                    }
+                    steps {
+                        runLibraryScript("addRpmMetaData.sh", "${env.NAME}.spec")
+                        sh "make prepare"
+                        sh "git update-index --assume-unchanged ${env.NAME}.spec"
+                    }
                 }
-            }
-            steps {
-                script {
-                    publishCsmRpms(
-                            arch: "noarch",
-                            component: env.NAME,
-                            isStable: isStable,
-                            os: "noos",
-                            pattern: "dist/rpmbuild/RPMS/noarch/*.rpm",
-                    )
-                    publishCsmRpms(
-                            arch: "src",
-                            component: env.NAME,
-                            isStable: isStable,
-                            os: "noos",
-                            pattern: "dist/rpmbuild/SRPMS/*.rpm",
-                    )
+
+                stage('Build: RPMs') {
+                    agent {
+                        docker {
+                            label "${PRIMARY_NODE}"
+                            reuseNode true
+                            image "${sleImage}"
+                        }
+                    }
+                    steps {
+                        sh "make rpm"
+                    }
+                }
+
+                stage('Publish: RPMs') {
+                    agent {
+                        docker {
+                            label "${PRIMARY_NODE}"
+                            reuseNode true
+                            args "-v /home/jenkins/.ssh:/home/jenkins/.ssh"
+                            image "${sleImage}"
+                        }
+                    }
+                    steps {
+                        script {
+                            publishCsmRpms(arch: "noarch",
+                                    component: env.NAME,
+                                    isStable: isStable,
+                                    os: "noos",
+                                    pattern: "dist/rpmbuild/RPMS/noarch/*.rpm",
+                            )
+                            publishCsmRpms(arch: "src",
+                                    component: env.NAME,
+                                    isStable: isStable,
+                                    os: "noos",
+                                    pattern: "dist/rpmbuild/SRPMS/*.rpm",
+                            )
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
Updates to the `Jenkinsfile.github`, primarily for publishing RPMs to `noos`.
