### PR TITLE
CASMHMS-6072: Remove reds from HMS CT test script

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.7.0] - 2023-09-25
+
+### Changed
+- Removed REDS from run_hms_ct_tests.sh
+
 ## [0.6.1] - 2023-07-28
 ### Changed
 - Added check for vShasta to run_hms_ct_tests.sh

--- a/scripts/hms_verification/run_hms_ct_tests.sh
+++ b/scripts/hms_verification/run_hms_ct_tests.sh
@@ -94,7 +94,6 @@ HBTD_ARR=("hbtd" "cray-hms-hbtd" 1 0 "none")
 HMNFD_ARR=("hmnfd" "cray-hms-hmnfd" 1 1 "none")
 HSM_ARR=("hsm" "cray-hms-smd" 1 1 "name=cray-hms-smd-test-smoke,name=cray-hms-smd-test-functional")
 PCS_ARR=("pcs" "cray-power-control" 1 1 "none")
-REDS_ARR=("reds" "cray-hms-reds" 1 0 "none")
 SCSD_ARR=("scsd" "cray-hms-scsd" 1 0 "none")
 SLS_ARR=("sls" "cray-hms-sls" 1 1 "none")
 
@@ -105,7 +104,6 @@ ALL_ARR=("${BSS_ARR[@]}" \
 "${HMNFD_ARR[@]}" \
 "${HSM_ARR[@]}" \
 "${PCS_ARR[@]}" \
-"${REDS_ARR[@]}" \
 "${SCSD_ARR[@]}" \
 "${SLS_ARR[@]}")
 
@@ -116,7 +114,6 @@ ${HBTD_ARR[0]} \
 ${HMNFD_ARR[0]} \
 ${HSM_ARR[0]} \
 ${PCS_ARR[0]} \
-${REDS_ARR[0]} \
 ${SCSD_ARR[0]} \
 ${SLS_ARR[0]}"
 
@@ -155,7 +152,6 @@ while getopts "hlt:p" opt; do
                "${HMNFD_ARR[0]}" | \
                "${HSM_ARR[0]}" | \
                "${PCS_ARR[0]}" | \
-               "${REDS_ARR[0]}" | \
                "${SCSD_ARR[0]}" | \
                "${SLS_ARR[0]}")
                    TEST_SERVICE=${OPTARG}
@@ -206,12 +202,6 @@ if [[ ${TEST_SERVICE} == "all" ]]; then
     echo "Running all tests..."
     for i in $(seq 0 5 $((${#ALL_ARR[@]} - 1))); do
         TEST_DEPLOYMENT=${ALL_ARR[$((${i} + 1))]}
-        if [[ "$TEST_DEPLOYMENT" == "cray-hms-reds" ]]; then
-            if is_vshasta_node; then
-                print_and_log "SKIPPED: ${TEST_DEPLOYMENT} test, running in vShasta"
-                continue
-            fi
-        fi
         FILTER_ARGS=${ALL_ARR[$((${i} + 4))]}
         if [[ "${FILTER_ARGS}" == "none" ]]; then
             helm test -n services ${TEST_DEPLOYMENT} >> ${LOG_PATH} 2>&1 &
@@ -253,11 +243,6 @@ if [[ ${TEST_SERVICE} == "all" ]]; then
         # data for service being tested
         TEST_SERVICE=${ALL_ARR[${i}]}
         TEST_DEPLOYMENT=${ALL_ARR[$((${i} + 1))]}
-        if [[ "$TEST_DEPLOYMENT" == "cray-hms-reds" ]]; then
-            if is_vshasta_node; then
-                continue
-            fi
-        fi
         TEST_SMOKE=${ALL_ARR[$((${i} + 2))]}
         TEST_FUNCTIONAL=${ALL_ARR[$((${i} + 3))]}
         # some services only have smoke tests, others also have functional tests
@@ -386,11 +371,6 @@ else
                          TEST_FUNCTIONAL="${PCS_ARR[3]}"
                          NUM_TESTS_EXPECTED=$((${PCS_ARR[2]} + ${PCS_ARR[3]}))
                          FILTER_ARGS="${PCS_ARR[4]}" ;;
-       "${REDS_ARR[0]}") TEST_DEPLOYMENT="${REDS_ARR[1]}"
-                         TEST_SMOKE="${REDS_ARR[2]}"
-                         TEST_FUNCTIONAL="${REDS_ARR[3]}"
-                         NUM_TESTS_EXPECTED=$((${REDS_ARR[2]} + ${REDS_ARR[3]}))
-                         FILTER_ARGS="${REDS_ARR[4]}" ;;
        "${SCSD_ARR[0]}") TEST_DEPLOYMENT="${SCSD_ARR[1]}"
                          TEST_SMOKE="${SCSD_ARR[2]}"
                          TEST_FUNCTIONAL="${SCSD_ARR[3]}"
@@ -404,13 +384,6 @@ else
             *) print_and_log "ERROR: invalid service: ${TEST_SERVICE}"
                exit 1 ;;
     esac
-
-    if [[ "$TEST_DEPLOYMENT" == "cray-hms-reds" ]]; then
-        if is_vshasta_node; then
-            print_and_log "SKIPPED: ${TEST_DEPLOYMENT} test, running in vShasta"
-            exit 0
-        fi
-    fi
 
     NUM_TESTS_PASSED=0
 


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_
Remove REDS from `run_hms_ct_tests.sh` as it will no longer be deployed in CSM 1.6.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_
backwards compatible.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMHMS-6072](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6072)

## Testing

_List the environments in which these changes were tested._

### Tested on:
  * Mug
  * Vshasta beau

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Yes
- Were continuous integration tests run? If not, why? N/A
- Was upgrade tested? If not, why? N/A
- Was downgrade tested? If not, why? N/A
- Were new tests (or test issues/Jiras) created for this change? N/A

__Mug testing__
Verified REDS was not in the list of services to test:
```bash
ncn-m001:/mnt/developer/rsjostrand/discovery # ./run_hms_ct_tests.sh -l
bss capmc fas hbtd hmnfd hsm pcs scsd sls
```

Verified REDS is not a allowed option:
```bash
ncn-m001:/mnt/developer/rsjostrand/discovery # ./run_hms_ct_tests.sh -t reds
ERROR: bad argument supplied to -t <service>, must be one of:
    all bss capmc fas hbtd hmnfd hsm pcs scsd sls
```

Was able to run all tests. On Mug FAS is unhealthy and that is why the test failed.
```
ncn-m001:/mnt/developer/rsjostrand/discovery # ./run_hms_ct_tests.sh
Log file for run is: /opt/cray/tests/hms_ct_test-20230927T143723.log
Running all tests...
DONE.
FAILURE: 1 service test FAILED (fas), 8 passed (bss, capmc, hbtd, hmnfd, hsm, pcs, scsd, sls)
For troubleshooting and manual steps, see: https://github.com/Cray-HPE/docs-csm/blob/main/troubleshooting/hms_ct_manual_run.md
```

Was able to run a single HMS test, and it passed. The issue with FAS was corrected.
```
ncn-m001:/mnt/developer/rsjostrand/discovery # ./run_hms_ct_tests.sh -t fas
Log file for run is: /opt/cray/tests/hms_ct_test-20230927T150155.log
Running fas tests...
DONE.
SUCCESS: Service test passed: fas
```

__Vshasta Testing__
```
ncn-m001:~/rsjostrand # ./run_hms_ct_tests.sh
Log file for run is: /opt/cray/tests/hms_ct_test-20230927T151220.log
Running all tests...
DONE.
SUCCESS: All 9 service tests passed: bss, capmc, fas, hbtd, hmnfd, hsm, pcs, scsd, sls
```

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_
No known issues.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

