### PR TITLE
MTL-2458

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-(C) Copyright [2021-2023] Hewlett Packard Enterprise Development LP
+(C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/scripts/node_management/make_node_groups
+++ b/scripts/node_management/make_node_groups
@@ -32,7 +32,7 @@ list_hsm_nodes() {
 
 list_uai_nodes() {
     kubectl get nodes \
-            --selector "uas notin (false, False, FALSE),! node-role.kubernetes.io/master" \
+            --selector "uas notin (false, False, FALSE),! node-role.kubernetes.io/control-plane" \
         | grep -v -e '^NAME ' \
         | awk '{ print $1 }'
 }


### PR DESCRIPTION
## Summary and Scope

node-role.kubernetes.io/master deprecated in k8s 1.24
replace it with node-role.kubernetes.io/control-plane

## Issues and Related PRs

https://jira-pro.it.hpe.com:8443/browse/MTL-2458

## Testing

### Tested on:

- fanta

## Post-merge checklist
- [x] tag 0.7.1
- [ ] update node-images
- [ ] update csm
- [ ] potentially update other repos

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable