### PR TITLE
CASMTRIAGE-7692 adjust `run_hms_ct_tests.sh` to reduce false positives

### DIFF
--- a/scripts/hms_verification/run_hms_ct_tests.sh
+++ b/scripts/hms_verification/run_hms_ct_tests.sh
@@ -121,7 +121,8 @@ ${SLS_ARR[0]}"
 TEST_SERVICE="all"
 PRINT_POD_LOGS=false
 DATE_TIME=$(date +"%Y%m%dT%H%M%S")
-LOG_PATH="/opt/cray/tests/hms_ct_test-${DATE_TIME}.log"
+LOG_BASE_DIR="/opt/cray/tests"
+LOG_PATH="$LOG_BASE_DIR/hms_ct_test-${DATE_TIME}.log"
 HELP_URL="https://github.com/Cray-HPE/docs-csm/blob/main/troubleshooting/hms_ct_manual_run.md"
 
 # parse command-line options
@@ -191,9 +192,10 @@ if ${PRINT_POD_LOGS}; then
     fi
 fi
 
-echo "Log file for run is: ${LOG_PATH}"
 
 if [[ ${TEST_SERVICE} == "all" ]]; then
+    echo "Log file for run is: ${LOG_PATH}"
+    
     #############################
     # Run all HMS service tests #
     #############################
@@ -388,6 +390,11 @@ else
     NUM_TESTS_PASSED=0
 
     echo "Running ${TEST_SERVICE} tests..."
+    # when executed in parallel, writing to the same log file causes unintended failures when parsing the output
+    # create a new file with the service name and timestamp to avoid this issue
+    LOG_PATH=$(mktemp "$LOG_BASE_DIR/hms_ct_test-${DATE_TIME}-${TEST_SERVICE}-XXXXXX.log")
+    echo "Log file for run is: ${LOG_PATH}"
+
     if [[ "${FILTER_ARGS}" == "none" ]]; then
         helm test -n services ${TEST_DEPLOYMENT} > ${LOG_PATH} 2>&1
     else


### PR DESCRIPTION
when running via goss

this changes the `else` condition of this wrapper script to use an alternate log file name to prevent false failures when running this script in parallel.

the main use case here is that the goss tests from csm-testing runs this script in several processes when called via goss, and they all try to read and write to the same log file.  this works ok when run serially, such as in a simple `for` loop, but when they are all kicked off at once, it can lead to odd situations like this completed log file:

```
NAME: cray-power-control
LAST DEPLOYED: Wed Aug 28 07:49:37 2024
NAMESPACE: services
STATUS: deployed
REVISION: 7
TEST SUITE:     cray-power-control-test-functional
Last Started:   Wed Jan 15 15:44:56 2025
Last Completed: Wed Jan 15 15:46:25 2025
Phase:          Succeeded
TEST SUITE:     cray-power-control-test-smoke
Last Started:   Wed Jan 15 15:44:24 2025
Last Completed: Wed Jan 15 15:44:56 2025
Phase:          Succeeded
         Succeeded
ray-hms-smd:

SUCCESS: Service test passed: sls

SUCCESS: Service test passed: bss

SUCCESS: Service test passed: capmc

SUCCESS: Service test passed: hsm

SUCCESS: Service test passed: fas

SUCCESS: Service test passed: pcs
```

text is truncated unintentionally and not all output is present.

this script is a bit fraigle in this sense, since we determine success or failure based on the output that is in this log file.  while this is a helpful wrapper for the customer because it shows a nice summary of output, but is less helpful for simple machines needing to check the exit status or just print the `helm` output.

there is not a lot of impact to the manual execution path, except that is creates a new log file if testing a single service.  so preventing false positives in the ct pipeline is worth it.

during testing, I tried different fixes including a file lock and other methods to not read/write to the same log file.  I ended up with this solution since the code was close together, making a review of it easier, and it also minimizes the footprint of the change.

the script hasn't had much work done for years, so I opted for this path instead of trying to re-work the entire thing and disrupting other places this script may be used.

